### PR TITLE
Ensure README file is properly closed by setup.py

### DIFF
--- a/setup.py.jinja2
+++ b/setup.py.jinja2
@@ -1,7 +1,8 @@
 import os
 from setuptools import setup
 
-README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme_file:
+    README = readme_file.read()
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))


### PR DESCRIPTION
The README file isn't closed in the setup.py. This commit fixes that by using the file in combination with a with statement. This should be possible as Python 2.7+ are supported.
