### PR TITLE
Added missing requirement for running tests: mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sqlparse==0.1.11
 Jinja2==2.7.2
 autopep8==1.0.2
 pytz>2014.2
+mock==1.0.1


### PR DESCRIPTION
Mock is missing in requirements.txt for setting up and running the tests. I believe it should be in there, correct me if I'm wrong.
