### PR TITLE
Added utf8 in curl query parameters

### DIFF
--- a/silk/code_generation/curl.py
+++ b/silk/code_generation/curl.py
@@ -22,7 +22,7 @@ def _curl_process_params(body, content_type, query_params):
     modifier = None
     if query_params:
         try:
-            query_params = urlencode(query_params)
+            query_params = urlencode([(k, v.encode('utf8')) for k, v in query_params.items()])
         except TypeError:
             pass
         query_params = '?' + str(query_params)


### PR DESCRIPTION
There is a problem if GET parameters contain non-ASCII symbols. `/silk/request/ID/`throws error 500 and complains on `urlencode`.

That's known issue with `urlencode` - it expects values in dict to be string, not unicode. So I've added explicit utf8-encoding here.

Tests for CURL are all commented out, so no test here. I can add it as a separate `TestCase`, if necessary.
