### PR TITLE
Avoid errors when doing migrate command

### DIFF
--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -28,7 +28,7 @@ def silky_reverse(name, *args, **kwargs):
     return r
 
 
-fpath = silky_reverse('summary')
+get_fpath = lambda: silky_reverse('summary')
 config = SilkyConfig()
 
 def _should_intercept(request):
@@ -42,7 +42,7 @@ def _should_intercept(request):
         if random.random() > config.SILKY_INTERCEPT_PERCENT / 100.0:
             return False
 
-    silky = request.path.startswith(fpath)
+    silky = request.path.startswith(get_fpath())
     ignored = request.path in config.SILKY_IGNORE_PATHS
     return not (silky or ignored)
 


### PR DESCRIPTION
This is my traceback:

``` bash
python manage.py migrate
Traceback (most recent call last):
  File "/home/ubuntu/webapps/smith/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 328, in execute
    django.setup()
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/django/apps/registry.py", line 115, in populate
    app_config.ready()
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/debug_toolbar/apps.py", line 16, in ready
    dt_settings.check_middleware()
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/debug_toolbar/settings.py", line 165, in check_middleware
    if is_middleware_class(GZipMiddleware, middleware):
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/debug_toolbar/settings.py", line 182, in is_middleware_class
    mod = import_module(mod_path)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/silk/middleware.py", line 31, in <module>
    fpath = silky_reverse('summary')
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/silk/middleware.py", line 27, in silky_reverse
    r = reverse(name, *args, **kwargs)
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 578, in reverse
    return force_text(iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs)))
  File "/home/ubuntu/venvs/agentsmith/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 495, in _reverse_with_prefix
    (lookup_view_s, args, kwargs, len(patterns), patterns))
django.core.urlresolvers.NoReverseMatch: Reverse for 'summary' with arguments '()' and keyword arguments '{}' not found. 0 pattern(s) tried: []
```
