### PR TITLE
Makes example_app.models.Product.photo.upload_to a string instead of bytes

### DIFF
--- a/project/example_app/models.py
+++ b/project/example_app/models.py
@@ -5,7 +5,7 @@ from django.db.models import TextField, BooleanField, ImageField
 
 
 class Product(models.Model):
-    photo = ImageField(upload_to=b'products')
+    photo = ImageField(upload_to='products')
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Hello,

When playing around with some changes to django-silk, I found an error in the example app.

Steps to repro:
  1) Run Django server
  2) Go to http://localhost:8000/admin/example_app/blind/add/ and upload a photo, and choose name.
  3) Click Save

Upon saving, the following (truncated) server exception occurred:
  ```
....
  File "/home/veer/Projects/silk/venv/lib/python3.5/site-packages/django/db/models/fields/files.py", line 86, in save
    name = self.field.generate_filename(self.instance, name)
  File "/home/veer/Projects/silk/venv/lib/python3.5/site-packages/django/db/models/fields/files.py", line 304, in generate_filename
    dirname = datetime.datetime.now().strftime(self.upload_to)
TypeError: strftime() argument 1 must be str, not bytes
```
It seems like this is down to a simple typo in the 'upload_to' params of example_app.models.Product.photo, passing in bytes instead of a string.  I've fixed it in this teeny PR.

I read the Contributing guidelines and the README, but please let me know if I missed something and there's some other way I should be approaching this (like filing an associated issue before sending a PR).

Thanks!