### PR TITLE
Truncate tables when running silk_clear_request_log

### DIFF
--- a/silk/management/commands/silk_clear_request_log.py
+++ b/silk/management/commands/silk_clear_request_log.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import connection
 
 import silk.models
 
@@ -8,6 +10,14 @@ class Command(BaseCommand):
 
     @staticmethod
     def delete_model(model):
+        engine = settings.DATABASES['default']['ENGINE']
+        if 'sqlite' not in engine:
+            # Use "TRUNCATE" on the table
+            cursor = connection.cursor()
+            cursor.execute("TRUNCATE TABLE %s", [model._meta.db_table])
+            return
+
+        # Manually delete rows because sqlite does not support TRUNCATE
         while True:
             items_to_delete = list(
                 model.objects.values_list('pk', flat=True).all()[:1000])


### PR DESCRIPTION
Fixes #239 

This should make `./manage.py silk_clear_request_log` run a lot faster by using `TRUNCATE` for non-sqlite databases.  I believe that `objects.all().delete()` won't run `TRUNCATE` on these tables because of foreign key checks.