### PR TITLE
Fix issue #274

### DIFF
--- a/silk/collector.py
+++ b/silk/collector.py
@@ -180,8 +180,7 @@ class DataCollector(with_metaclass(Singleton, object)):
                         )
             profile = models.Profile.objects.create(**profile)
             if profile_query_models:
-                profile.queries = profile_query_models
-                profile.save()
+                profile.queries.set(profile_query_models)
         self._record_meta_profiling()
 
     def register_silk_query(self, *args):


### PR DESCRIPTION
Use `set` method instead of `__set__` on a
`ManyToManyField` to ensure compatibility with
Django 2.0 and higher.

See issue #274 for details.