### PR TITLE
Fix view name

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -169,12 +169,7 @@ class RequestModelFactory(object):
         return encoded_query_params
 
     def view_name(self):
-        try:
-            resolved = resolve(self.request.path)
-        except Resolver404:
-            return None
-
-        return resolved.view_name
+        return self.request.resolver_match.url_name
 
     def construct_request_model(self):
         body, raw_body = self.body()

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -169,7 +169,12 @@ class RequestModelFactory(object):
         return encoded_query_params
 
     def view_name(self):
-        return self.request.resolver_match.url_name
+        try:
+            resolved = resolve(self.request.path_info)
+        except Resolver404:
+            return None
+
+        return resolved.view_name
 
     def construct_request_model(self):
         body, raw_body = self.body()


### PR DESCRIPTION
Default resolver doesn't work with FORCE_SCRIPT_NAME used. This way view_name is None.
like: excample.com/backend/is-authenticated/ 
WSGIReqeust variable called path_info contains url without prefix.
https://docs.djangoproject.com/en/2.0/ref/request-response/#django.http.HttpRequest.path_info