### PR TITLE
Fix garbage collection logic for small tables

### DIFF
--- a/silk/models.py
+++ b/silk/models.py
@@ -148,6 +148,7 @@ class Request(models.Model):
         requests = cls.objects.order_by('-start_time')
         if not requests:
             return
+        target_count = max(len(requests)-1, target_count)
         time_cutoff = requests[target_count].start_time
         cls.objects.filter(start_time__lte=time_cutoff).delete()
 

--- a/silk/models.py
+++ b/silk/models.py
@@ -148,7 +148,8 @@ class Request(models.Model):
         requests = cls.objects.order_by('-start_time')
         if not requests:
             return
-        target_count = max(len(requests)-1, target_count)
+        if len(requests)-1 < target_count:
+            return
         time_cutoff = requests[target_count].start_time
         cls.objects.filter(start_time__lte=time_cutoff).delete()
 

--- a/silk/models.py
+++ b/silk/models.py
@@ -146,9 +146,7 @@ class Request(models.Model):
             cls.objects.all().delete()
             return
         requests = cls.objects.order_by('-start_time')
-        if not requests:
-            return
-        if len(requests)-1 < target_count:
+        if not requests or len(requests)-1 < target_count:
             return
         time_cutoff = requests[target_count].start_time
         cls.objects.filter(start_time__lte=time_cutoff).delete()


### PR DESCRIPTION
This makes sure that there will be no `IndexErrors` when calling the `garbage_collect` method.  I'm guessing this may be possible if there are fewer `Request`s than the target number of requests.

cc @avelis @drppi44 

Replaces #279 