### PR TITLE
#290 Fix silk_clear_request_log errors on Postgres

### DIFF
--- a/silk/management/commands/silk_clear_request_log.py
+++ b/silk/management/commands/silk_clear_request_log.py
@@ -14,16 +14,15 @@ class Command(BaseCommand):
         table = model._meta.db_table
         if 'mysql' in engine or 'postgresql' in engine:
             # Use "TRUNCATE" on the table
-            cursor = connection.cursor()
-            if 'mysql' in engine:
-                cursor.execute("SET FOREIGN_KEY_CHECKS=0;")
-            if 'postgres' in engine:
-                cursor.execute("ALTER TABLE %s DISABLE TRIGGER ALL;", [table])
-            cursor.execute("TRUNCATE TABLE %s", [table])
-            if 'mysql' in engine:
-                cursor.execute("SET FOREIGN_KEY_CHECKS=1;")
-            if 'postgres' in engine:
-                cursor.execute("ALTER TABLE %s ENABLE TRIGGER ALL;", [table])
+            with connection.cursor() as cursor:
+                if 'mysql' in engine:
+                    cursor.execute("SET FOREIGN_KEY_CHECKS=0;")
+                    cursor.execute("TRUNCATE TABLE {0}".format(table))
+                    cursor.execute("SET FOREIGN_KEY_CHECKS=1;")
+                elif 'postgres' in engine:
+                    cursor.execute("ALTER TABLE {0} DISABLE TRIGGER ALL;".format(table))
+                    cursor.execute("TRUNCATE TABLE {0} CASCADE".format(table))
+                    cursor.execute("ALTER TABLE {0} ENABLE TRIGGER ALL;".format(table))
             return
 
         # Manually delete rows because sqlite does not support TRUNCATE and


### PR DESCRIPTION
Fix issue #290 

To not complicate the code, I removed quoting of the table name (by not passing as DB parameter which gets single quoted), as they shouldn't contain invalid characters that need escaped (non-user input), and avoids DB-specific quoting issues.

Split mysql and postgres logic to handle `TRUNCATE ... CASCADE` with postgres.  Since we're removing all silk data from the DB, this should be relatively safe unless someone created a foreign key from a custom table into a silk table (why?)

Also, added `with` around cursor for cleanup, even though the script is short-lived.

Let me know if this is an acceptable solution however!
Thanks!
Mike