### PR TITLE
Added a simple view in request detail context allowing to get python profile

### DIFF
--- a/silk/templates/silk/cprofile.html
+++ b/silk/templates/silk/cprofile.html
@@ -1,0 +1,99 @@
+{% extends "silk/base/detail_base.html" %}
+{% load silk_filters %}
+{% load silk_nav %}
+{% load silk_inclusion %}
+{% load staticfiles %}
+
+{% block js %}
+    <script type="text/javascript" src="{% static 'silk/lib/viz-lite.js' %}"></script>
+    <script type="text/javascript" src="{% static 'silk/lib/svg-pan-zoom.min.js' %}"></script>
+    {{ block.super }}
+{% endblock %}
+
+{% block style %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'silk/css/summary.css' %}">
+    <style>
+        #query-info-div {
+            margin-top: 15px;
+        }
+
+        #query-info-div .timestamp-div {
+            font-size: 13px;
+
+        }
+
+        #pyprofile-div {
+            display: block;
+            margin: auto;
+            width: 960px;
+        }
+
+        .pyprofile {
+            text-align: left;
+        }
+
+        a {
+            color: #45ADA8;
+        }
+
+        a:visited {
+            color: #45ADA8;
+        }
+
+        a:hover {
+            color: #547980;
+        }
+
+        a:active {
+            color: #594F4F;
+        }
+
+        #graph-div {
+            padding: 25px;
+            background-color: white;
+            display: block;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: 25px;
+            width: 960px;
+            text-align: center;
+        }
+
+        #percent {
+            width: 20px;
+        }
+
+        svg {
+          display: block;
+        }
+
+    </style>
+{% endblock %}
+
+{% block menu %}
+    {% request_menu request silk_request %}
+{% endblock %}
+
+
+{% block data %}
+    <div class="wrapper">
+        <div id="query-div">           
+            {% if silk_request.pyprofile %}
+            <div id="pyprofile-div">
+                <div class="heading">
+                    <div class="inner-heading">CProfile</div>
+                </div>
+                <div class="description">
+                    The below is a dump from the cPython profiler.
+                </div>
+                {% if silk_request.prof_file %}
+                Click <a href="{% url 'silk:request_profile_download' request_id=silk_request.pk %}">here</a> to download profile.
+                {% endif %}
+                <pre class="pyprofile">{{ silk_request.pyprofile }}</pre>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+{% endblock %}

--- a/silk/templates/silk/inclusion/request_menu.html
+++ b/silk/templates/silk/inclusion/request_menu.html
@@ -30,3 +30,11 @@
         </div>
     </div>
 </a>
+
+<a href="{% url "silk:cprofile" silk_request.id %}">
+    <div class="menu-item {% navactive request 'silk:cprofile' silk_request.id %} selectable-menu-item">
+        <div class="menu-item-outer">
+            <div class="menu-item-inner">CProfile</div>
+        </div>
+    </div>
+</a>

--- a/silk/urls.py
+++ b/silk/urls.py
@@ -10,6 +10,7 @@ from silk.views.requests import RequestsView
 from silk.views.sql import SQLView
 from silk.views.sql_detail import SQLDetailView
 from silk.views.summary import SummaryView
+from silk.views.cprofile import CProfileView
 
 app_name = 'silk'
 urlpatterns = [
@@ -80,5 +81,10 @@ urlpatterns = [
         SQLDetailView.as_view(),
         name='profile_sql_detail'
     ),
-    url(r'^profiling/$', ProfilingView.as_view(), name='profiling')
+    url(r'^profiling/$', ProfilingView.as_view(), name='profiling'),
+    url(
+        r'^request/(?P<request_id>[a-zA-Z0-9\-]+)/cprofile/$',
+        CProfileView.as_view(),
+        name='cprofile'
+    ),
 ]

--- a/silk/views/cprofile.py
+++ b/silk/views/cprofile.py
@@ -1,0 +1,21 @@
+from django.shortcuts import render
+from django.utils.decorators import method_decorator
+from django.views.generic import View
+from silk.auth import login_possibly_required, permissions_possibly_required
+from silk.models import Profile
+from silk.views.code import _code_context, _code_context_from_request
+from silk.models import Request
+
+
+class CProfileView(View):
+
+    @method_decorator(login_possibly_required)
+    @method_decorator(permissions_possibly_required)
+    def get(self, request, *_, **kwargs):
+        request_id = kwargs['request_id']        
+        silk_request = Request.objects.get(pk=request_id)
+        context = {
+            'silk_request': silk_request,            
+            'request': request}
+            
+        return render(request, 'silk/cprofile.html', context)


### PR DESCRIPTION
After checking multiple times, I figured out that python profile is provided only on the profile detailed page which is reachable from the profiling view only if some dynamic, decorator or context manager profile are defined. I simply created a new view allowing to get the python profile for each and every queries.

![capture](https://user-images.githubusercontent.com/29102231/42606543-87df2efe-857e-11e8-898e-30769719bc98.PNG)
