### PR TITLE
Modernize middleware

### DIFF
--- a/project/tests/test_config_meta.py
+++ b/project/tests/test_config_meta.py
@@ -8,6 +8,11 @@ from .util import delete_all_models
 from silk.config import SilkyConfig
 from silk.models import Request
 
+def fake_get_response():
+    def fake_response():
+        return 'hello world'
+    return fake_response
+
 
 class TestConfigMeta(TestCase):
     def _mock_response(self):
@@ -23,7 +28,7 @@ class TestConfigMeta(TestCase):
         delete_all_models(Request)
         DataCollector().configure(Request.objects.create())
         response = self._mock_response()
-        SilkyMiddleware()._process_response('', response)
+        SilkyMiddleware(fake_get_response)._process_response('', response)
         self.assertTrue(response.status_code == 200)
         objs = Request.objects.all()
         self.assertEqual(objs.count(), 1)

--- a/project/tests/test_silky_middleware.py
+++ b/project/tests/test_silky_middleware.py
@@ -8,10 +8,15 @@ from silk.models import Request
 
 from .util import mock_data_collector
 
+def fake_get_response():
+    def fake_response():
+        return 'hello world'
+    return fake_response
+
 
 class TestApplyDynamicMappings(TestCase):
     def test_dynamic_decorator(self):
-        middleware = SilkyMiddleware()
+        middleware = SilkyMiddleware(fake_get_response)
         SilkyConfig().SILKY_DYNAMIC_PROFILING = [
             {
                 'module': 'tests.data.dynamic',
@@ -27,7 +32,7 @@ class TestApplyDynamicMappings(TestCase):
             self.assertTrue(mock_DataCollector.return_value.register_profile.call_count)
 
     def test_dynamic_context_manager(self):
-        middleware = SilkyMiddleware()
+        middleware = SilkyMiddleware(fake_get_response)
         SilkyConfig().SILKY_DYNAMIC_PROFILING = [
             {
                 'module': 'tests.data.dynamic',
@@ -45,7 +50,7 @@ class TestApplyDynamicMappings(TestCase):
             self.assertTrue(mock_DataCollector.return_value.register_profile.call_count)
 
     def test_invalid_dynamic_context_manager(self):
-        middleware = SilkyMiddleware()
+        middleware = SilkyMiddleware(fake_get_response)
         SilkyConfig().SILKY_DYNAMIC_PROFILING = [
             {
                 'module': 'tests.data.dynamic',
@@ -57,7 +62,7 @@ class TestApplyDynamicMappings(TestCase):
         self.assertRaises(IndexError, middleware._apply_dynamic_mappings)
 
     def test_invalid_dynamic_decorator_module(self):
-        middleware = SilkyMiddleware()
+        middleware = SilkyMiddleware(fake_get_response)
         SilkyConfig().SILKY_DYNAMIC_PROFILING = [
             {
                 'module': 'tests.data.dfsdf',
@@ -67,7 +72,7 @@ class TestApplyDynamicMappings(TestCase):
         self.assertRaises(AttributeError, middleware._apply_dynamic_mappings)
 
     def test_invalid_dynamic_decorator_function_name(self):
-        middleware = SilkyMiddleware()
+        middleware = SilkyMiddleware(fake_get_response)
         SilkyConfig().SILKY_DYNAMIC_PROFILING = [
             {
                 'module': 'tests.data.dynamic',
@@ -77,7 +82,7 @@ class TestApplyDynamicMappings(TestCase):
         self.assertRaises(AttributeError, middleware._apply_dynamic_mappings)
 
     def test_invalid_dynamic_mapping(self):
-        middleware = SilkyMiddleware()
+        middleware = SilkyMiddleware(fake_get_response)
         SilkyConfig().SILKY_DYNAMIC_PROFILING = [
             {
                 'dfgdf': 'tests.data.dynamic',
@@ -87,7 +92,7 @@ class TestApplyDynamicMappings(TestCase):
         self.assertRaises(KeyError, middleware._apply_dynamic_mappings)
 
     def test_no_mappings(self):
-        middleware = SilkyMiddleware()
+        middleware = SilkyMiddleware(fake_get_response)
         SilkyConfig().SILKY_DYNAMIC_PROFILING = [
 
         ]

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -5,7 +5,6 @@ from django.db import transaction, DatabaseError
 from django.urls import reverse, NoReverseMatch
 from django.db.models.sql.compiler import SQLCompiler
 from django.utils import timezone
-from django.utils.deprecation import MiddlewareMixin
 
 from silk.collector import DataCollector
 
@@ -57,7 +56,19 @@ class TestMiddleware(object):
         return
 
 
-class SilkyMiddleware(MiddlewareMixin):
+class SilkyMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        self.process_request(request)
+
+        response = self.get_response(request)
+
+        response = self.process_response(request, response)
+
+        return response
+
     def _apply_dynamic_mappings(self):
         dynamic_profile_configs = config.SILKY_DYNAMIC_PROFILING
         for conf in dynamic_profile_configs:

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -56,7 +56,7 @@ class TestMiddleware(object):
         return
 
 
-class SilkyMiddleware(object):
+class SilkyMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 


### PR DESCRIPTION
As django-silk no longer supports django < 1.10 the MiddlewareMixin is
no longer needed.