### PR TITLE
Fix #297 remove explicit byte string from migration 0003

### DIFF
--- a/silk/migrations/0003_request_prof_file.py
+++ b/silk/migrations/0003_request_prof_file.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='request',
             name='prof_file',
-            field=models.FileField(null=True, upload_to=b''),
+            field=models.FileField(null=True, upload_to=''),
         ),
     ]


### PR DESCRIPTION
Explanation see jazzband#297
Dropping the explicit `b` prefix while unicode_literals are imported will default this string to a unicode string in both Python 2.x and 3.x.
The proposed change was tested under Python 3.6.5 (Anaconda distribution) and Django 2.0.7.