### PR TITLE
Disable postgres USER triggers

### DIFF
--- a/silk/management/commands/silk_clear_request_log.py
+++ b/silk/management/commands/silk_clear_request_log.py
@@ -20,9 +20,9 @@ class Command(BaseCommand):
                     cursor.execute("TRUNCATE TABLE {0}".format(table))
                     cursor.execute("SET FOREIGN_KEY_CHECKS=1;")
                 elif 'postgres' in engine:
-                    cursor.execute("ALTER TABLE {0} DISABLE TRIGGER ALL;".format(table))
+                    cursor.execute("ALTER TABLE {0} DISABLE TRIGGER USER;".format(table))
                     cursor.execute("TRUNCATE TABLE {0} CASCADE".format(table))
-                    cursor.execute("ALTER TABLE {0} ENABLE TRIGGER ALL;".format(table))
+                    cursor.execute("ALTER TABLE {0} ENABLE TRIGGER USER;".format(table))
             return
 
         # Manually delete rows because sqlite does not support TRUNCATE and


### PR DESCRIPTION
To be able to disable ALL triggers on a database, one needs a user that can disable system triggers.

Should fix https://github.com/jazzband/django-silk/issues/290