### PR TITLE
If there is no DataCollector().request then don't wrap sql queries

### DIFF
--- a/silk/sql.py
+++ b/silk/sql.py
@@ -11,6 +11,9 @@ Logger = logging.getLogger('silk.sql')
 
 
 def _should_wrap(sql_query):
+    if not DataCollector().request:
+        return False
+
     for ignore_str in SilkyConfig().SILKY_IGNORE_QUERIES:
         if ignore_str in sql_query:
             return False


### PR DESCRIPTION
This is a potential fix for issue #319 