### PR TITLE
Sort view filters values

### DIFF
--- a/project/tests/test_view_requests.py
+++ b/project/tests/test_view_requests.py
@@ -14,7 +14,6 @@ class TestRootViewDefaults(TestCase):
         paths = RequestsView()._get_paths()
         for r in requests:
             self.assertIn(r.path, paths)
-        self.assertIn('', paths)
 
     def test_show(self):
         self.assertIn(RequestsView.default_show, RequestsView.show)
@@ -35,8 +34,8 @@ class TestContext(TestCase):
                                           'options_show': RequestsView.show,
                                           'options_order_by': RequestsView().options_order_by,
                                           'options_order_dir': RequestsView().options_order_dir,
-                                          'options_paths': RequestsView()._get_paths()
                                       }, context)
+        self.assertQuerysetEqual(context['options_paths'], RequestsView()._get_paths())
         self.assertNotIn('path', context)
         self.assertIn('results', context)
 
@@ -57,8 +56,8 @@ class TestContext(TestCase):
                                           'options_show': RequestsView.show,
                                           'options_order_by': RequestsView().options_order_by,
                                           'options_order_dir': RequestsView().options_order_dir,
-                                          'options_paths': RequestsView()._get_paths()
                                       }, context)
+        self.assertQuerysetEqual(context['options_paths'], RequestsView()._get_paths())
         self.assertIn('results', context)
 
 

--- a/silk/views/requests.py
+++ b/silk/views/requests.py
@@ -60,13 +60,38 @@ class RequestsView(View):
         return [{'value': x, 'label': self.order_dir[x]['label']} for x in self.order_dir.keys()]
 
     def _get_paths(self):
-        return [''] + [x['path'] for x in Request.objects.values('path').distinct()]
+        return Request.objects.values_list(
+            'path',
+            flat=True
+        ).order_by(
+            'path'
+        ).distinct()
+
+    def _get_views(self):
+        return Request.objects.values_list(
+            'view_name',
+            flat=True
+        ).exclude(
+            view_name=''
+        ).order_by(
+            'view_name'
+        ).distinct()
 
     def _get_status_codes(self):
-        return [x['status_code'] for x in Response.objects.values('status_code').distinct()]
+        return Response.objects.values_list(
+            'status_code',
+            flat=True
+        ).order_by(
+            'status_code'
+        ).distinct()
 
     def _get_methods(self):
-        return [x['method'] for x in Request.objects.values('method').distinct()]
+        return Request.objects.values_list(
+            'method',
+            flat=True
+        ).order_by(
+            'method'
+        ).distinct()
 
     def _get_objects(self, show=None, order_by=None, order_dir=None, path=None, filters=None):
         if not filters:
@@ -110,7 +135,7 @@ class RequestsView(View):
             'options_paths': self._get_paths(),
             'options_status_codes': self._get_status_codes(),
             'options_methods': self._get_methods(),
-            'view_names': [x[0] for x in Request.objects.values_list('view_name').distinct() if x[0]],
+            'view_names': self._get_views(),
             'filters': raw_filters
         }
         context.update(csrf(request))


### PR DESCRIPTION
So that they are usable. We can remove the empty string path as we
already have it in the template.
While at it move all the calculation to the database for filtering
and flattening the data.