### PR TITLE
SILKY_MIDDLEWARE_CLASS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ INSTALLED_APPS = (
 
 **Note:** If you are using `django.middleware.gzip.GZipMiddleware`, place that **before** `silk.middleware.SilkyMiddleware`, otherwise you will get an encoding error.
 
+If you want to use custom middleware, for example you developed the subclass of `silk.middleware.SilkyMiddleware`, so you can use this combination of settings:
+
+```python
+# Specify the path where is the custom middleware placed
+SILKY_MIDDLEWARE_CLASS = 'path.to.your.middleware.MyCustomSilkyMiddleware'
+
+# Use this variable in list of middleware
+MIDDLEWARE = [
+    ...
+    SILKY_MIDDLEWARE_CLASS,
+    ...
+]
+```
+
 To enable access to the user interface add the following to your `urls.py`:
 
 ```python

--- a/silk/config.py
+++ b/silk/config.py
@@ -28,7 +28,8 @@ class SilkyConfig(six.with_metaclass(Singleton, object)):
         'SILKY_INTERCEPT_PERCENT': 100,
         'SILKY_INTERCEPT_FUNC': None,
         'SILKY_PYTHON_PROFILER': False,
-        'SILKY_STORAGE_CLASS': 'silk.storage.ProfilerResultStorage'
+        'SILKY_STORAGE_CLASS': 'silk.storage.ProfilerResultStorage',
+        'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware'
     }
 
     def _setup(self):

--- a/silk/profiling/profiler.py
+++ b/silk/profiling/profiler.py
@@ -127,7 +127,7 @@ class silk_profile(object):
         middlewares = getattr(settings, 'MIDDLEWARE', [])
         if not middlewares:
             middlewares = []
-        middleware_installed = 'silk.middleware.SilkyMiddleware' in middlewares
+        middleware_installed = SilkyConfig().SILKY_MIDDLEWARE_CLASS in middlewares
         return app_installed and middleware_installed
 
     def _should_profile(self):


### PR DESCRIPTION
Hello. Currently, there is no possibility to subclass the `SilkyMiddleware` and use it, because `profiling._silk_installed` always checks for `silk.middleware.SilkyMiddleware` inclusion in the middleware list. Can I suggest this option?
