### PR TITLE
Fix masking sensitive data in batch JSON request

### DIFF
--- a/project/tests/test_sensitive_data_in_request.py
+++ b/project/tests/test_sensitive_data_in_request.py
@@ -43,3 +43,22 @@ class TestEncodingForRequests(TestCase):
         self.assertNotIn('test_username', body)
         self.assertNotIn('testpassword', body)
 
+    def test_password_in_batched_json(self):
+        mock_request = Mock()
+        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'application/json; charset=UTF-8'}
+        d = [
+            {'x': 'testunmasked', 'username': 'test_username', 'password': 'testpassword'},
+            {'x': 'testunmasked', 'username': 'test_username', 'password': 'testpassword'}
+        ]
+        mock_request.body = json.dumps(d)
+        mock_request.get = mock_request.META.get
+        factory = RequestModelFactory(mock_request)
+        body, raw_body = factory.body()
+        self.assertIn('testunmasked', raw_body)
+        self.assertNotIn('test_username', raw_body)
+        self.assertNotIn('testpassword', raw_body)
+        self.assertNotIn('test_username', body[0])
+        self.assertNotIn('testpassword', body[0])
+        self.assertNotIn('test_username', body[1])
+        self.assertNotIn('testpassword', body[1])
+


### PR DESCRIPTION
Tried to use django-silk with the GraphQL server library [graphene-django](https://github.com/graphql-python/graphene-django) with their view running in batch mode
```python
from django.conf.urls import url
from graphene_django.views import GraphQLView
urlpatterns = [
    url(r'^graphql$', GraphQLView.as_view(graphiql=True, batch=True)),
]
```
This adds support for JSON requests with a list as the root element.