### PR TITLE
templates: limit select width to its container one

### DIFF
--- a/silk/templates/silk/base/root_base.html
+++ b/silk/templates/silk/base/root_base.html
@@ -189,6 +189,7 @@
 
     select {
         border-radius: 0;
+        max-width: 100%;
     }
 
     @media screen and (-webkit-min-device-pixel-ratio: 0) {


### PR DESCRIPTION
So it's actually possible to use them in the filter with very
long paths.

Fix the issue for me in both chrome and firefox.