### PR TITLE
Fix hiding of sensitive data in requests

### DIFF
--- a/project/tests/test_sensitive_data_in_request.py
+++ b/project/tests/test_sensitive_data_in_request.py
@@ -11,6 +11,76 @@ DJANGO_META_CONTENT_TYPE = 'CONTENT_TYPE'
 HTTP_CONTENT_TYPE = 'Content-Type'
 
 
+class MaskCredentialsInFormsTest(TestCase):
+    def _mask(self, value):
+        return RequestModelFactory(None)._mask_credentials(value)
+
+    def test_mask_credentials_preserves_single_insensitive_values(self):
+        self.assertIn("public", self._mask("foo=public"))
+
+    def test_mask_credentials_preserves_insensitive_values_between_sensitive_values(self):
+        self.assertIn("public", self._mask("password=1&foo=public&secret=2"))
+
+    def test_mask_credentials_masks_sensitive_values(self):
+        self.assertNotIn("secret", self._mask("password=secret"))
+
+    def test_mask_credentials_masks_sensitive_values_between_insensitive_values(self):
+        self.assertNotIn("secret", self._mask("public1=foo&password=secret&public2=bar"))
+
+    def test_mask_credentials_is_case_insensitive(self):
+        self.assertNotIn("secret", self._mask("UsErNaMe=secret"))
+
+    def test_mask_credentials_handles_prefixes(self):
+        self.assertNotIn("secret", self._mask("prefixed-username=secret"))
+
+    def test_mask_credentials_handles_suffixes(self):
+        self.assertNotIn("secret", self._mask("username-with-suffix=secret"))
+
+    def test_mask_credentials_handles_complex_cases(self):
+        self.assertNotIn("secret", self._mask("foo=public&prefixed-uSeRname-with-suffix=secret&bar=public"))
+
+
+class MaskCredentialsInJsonTest(TestCase):
+    def _mask(self, value):
+        return RequestModelFactory(None)._mask_credentials(json.dumps(value))
+
+    def test_mask_credentials_preserves_single_insensitive_values(self):
+        self.assertIn("public", self._mask({"foo": "public"}))
+
+    def test_mask_credentials_preserves_insensitive_values_in_presence_of_sensitive(self):
+        self.assertIn("public", self._mask({"password": "secret", "foo": "public"}))
+
+    def test_mask_credentials_masks_sensitive_values(self):
+        self.assertNotIn("secret", self._mask({"password": "secret"}))
+
+    def test_mask_credentials_masks_sensitive_values_in_presence_of_regular(self):
+        self.assertNotIn("secret", self._mask({"foo": "public", "password": "secret"}))
+
+    def test_mask_credentials_is_case_insensitive(self):
+        self.assertNotIn("secret", self._mask({"UsErNaMe": "secret"}))
+
+    def test_mask_credentials_handles_prefixes(self):
+        self.assertNotIn("secret", self._mask({"prefixed-username": "secret"}))
+
+    def test_mask_credentials_handles_suffixes(self):
+        self.assertNotIn("secret", self._mask({"username-with-suffix": "secret"}))
+
+    def test_mask_credentials_handles_complex_cases(self):
+        self.assertNotIn("secret", self._mask({
+            "foo": "public",
+            "prefixed-uSeRname-with-suffix": "secret"
+        }))
+
+    def test_mask_credentials_in_nested_data_structures(self):
+        self.assertNotIn("secret", self._mask({
+            "foo": "public",
+            "nested": {
+                "prefixed-uSeRname-with-suffix": "secret",
+            },
+        }))
+
+
+
 class TestEncodingForRequests(TestCase):
     """
     Check that the RequestModelFactory masks sensitive data
@@ -33,7 +103,8 @@ class TestEncodingForRequests(TestCase):
     def test_password_in_json(self):
         mock_request = Mock()
         mock_request.META = {DJANGO_META_CONTENT_TYPE: 'application/json; charset=UTF-8'}
-        d = {'x': 'testunmasked', 'username': 'test_username', 'password': 'testpassword'}
+        d = {'x': 'testunmasked', 'username': 'test_username', 'password': 'testpassword',
+             'prefixed-secret': 'testsecret'}
         mock_request.body = json.dumps(d)
         mock_request.get = mock_request.META.get
         factory = RequestModelFactory(mock_request)
@@ -41,12 +112,15 @@ class TestEncodingForRequests(TestCase):
         self.assertIn('testunmasked', raw_body)
         self.assertNotIn('test_username', raw_body)
         self.assertNotIn('testpassword', raw_body)
+        self.assertNotIn('testsecret', raw_body)
         self.assertNotIn('test_username', body)
         self.assertNotIn('testpassword', body)
+        self.assertNotIn('testsecret', body)
 
         for datum in [json.loads(body), json.loads(raw_body)]:
             self.assertEqual(datum['username'], RequestModelFactory.CLEANSED_SUBSTITUTE)
             self.assertEqual(datum['password'], RequestModelFactory.CLEANSED_SUBSTITUTE)
+            self.assertEqual(datum['prefixed-secret'], RequestModelFactory.CLEANSED_SUBSTITUTE)
             self.assertEqual(datum['x'], 'testunmasked')
 
     def test_password_in_batched_json(self):


### PR DESCRIPTION
The previous implementation does not correctly handle:

- prefixes in json
- suffixes in forms & json
- case sensitivity in forms & json
- nested values in json

These changes should fix the above issues.