### PR TITLE
One migration pending in 1.1.0

### DIFF
--- a/silk/migrations/0006_request_prof_file_storage.py
+++ b/silk/migrations/0006_request_prof_file_storage.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import silk.storage
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('silk', '0005_increase_request_prof_file_length'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='request',
+            name='prof_file',
+            field=models.FileField(default='', storage=silk.storage.ProfilerResultStorage(), max_length=300,
+                                   upload_to=b'', blank=True),
+            preserve_default=False,
+        ),
+    ]


### PR DESCRIPTION
Migrations doesn't reflect the current Request#prof_file attribute, so one migration is still pending to be generated. That difficulties working with the library in some CI and automated environments