### PR TITLE
Wrap re.sub() in try-except

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -128,7 +128,10 @@ class RequestModelFactory(object):
                 Logger.debug('{}'.format(str(e)))
             else:
                 for res in results:
-                    body = re.sub(res[1], RequestModelFactory.CLEANSED_SUBSTITUTE, body)
+                    try:
+                        body = re.sub(res[1], RequestModelFactory.CLEANSED_SUBSTITUTE, body)
+                    except Exception:
+                        Logger.debug('{}'.format(str(e)))
         else:
             body = json.dumps(replace_pattern_values(json_body))
 


### PR DESCRIPTION
If credentials ends with `\` (for example: `--password=123456\`) re.sub() fails with error `bad escape (end of pattern)`.