### PR TITLE
Replace the call to re.findall with re.sub in _mask_credentials so matched values are not treated as regex patterns

### DIFF
--- a/project/tests/test_sensitive_data_in_request.py
+++ b/project/tests/test_sensitive_data_in_request.py
@@ -36,6 +36,9 @@ class MaskCredentialsInFormsTest(TestCase):
     def test_mask_credentials_handles_suffixes(self):
         self.assertNotIn("secret", self._mask("username-with-suffix=secret"))
 
+    def test_mask_credentials_handles_regex_characters(self):
+        self.assertNotIn("secret", self._mask("password=secret++"))
+
     def test_mask_credentials_handles_complex_cases(self):
         self.assertNotIn("secret", self._mask("foo=public&prefixed-uSeRname-with-suffix=secret&bar=public"))
 

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -123,15 +123,9 @@ class RequestModelFactory(object):
         except Exception as e:
             pattern = re.compile(r'({})[^=]*=(.*?)(&|$)'.format(key_string), re.M | re.I)
             try:
-                results = re.findall(pattern, body)
+                body = re.sub(pattern, '\\1={}\\3'.format(RequestModelFactory.CLEANSED_SUBSTITUTE), body)
             except Exception:
                 Logger.debug('{}'.format(str(e)))
-            else:
-                for res in results:
-                    try:
-                        body = re.sub(res[1], RequestModelFactory.CLEANSED_SUBSTITUTE, body)
-                    except Exception:
-                        Logger.debug('{}'.format(str(e)))
         else:
             body = json.dumps(replace_pattern_values(json_body))
 


### PR DESCRIPTION
This fixes https://github.com/jazzband/django-silk/issues/410

This also fixes a DoS attack:
* Form is submitted with multiple empty fields that match the mask filter
* Substitution loop repeatedly calls `re.sub` with an empty pattern
* Cleansed string is inserted between every pair of characters
* Loop iterations causes exponential growth of body string, preventing the request from ever finishing