### PR TITLE
Clear DB error when configuring silk to use a non-' default' database

### DIFF
--- a/silk/utils/data_deletion.py
+++ b/silk/utils/data_deletion.py
@@ -3,7 +3,7 @@ from django.db import connection
 
 
 def delete_model(model):
-    engine = settings.DATABASES['default']['ENGINE']
+    engine = settings.DATABASES[model.objects.db]['ENGINE']
     table = model._meta.db_table
     if 'mysql' in engine or 'postgresql' in engine:
         # Use "TRUNCATE" on the table


### PR DESCRIPTION
resolve```django.db.utils.ProgrammingError: relation "silk_profile" does not exist```