### PR TITLE
Add the SILKY_JSON_ENSURE_ASCII configuration item to support Chinese

### DIFF
--- a/silk/config.py
+++ b/silk/config.py
@@ -28,7 +28,8 @@ class SilkyConfig(metaclass=Singleton):
         'SILKY_PYTHON_PROFILER': False,
         'SILKY_PYTHON_PROFILER_FUNC': None,
         'SILKY_STORAGE_CLASS': 'silk.storage.ProfilerResultStorage',
-        'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware'
+        'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware',
+        'SILKY_JSON_ENSURE_ASCII': True,
     }
 
     def _setup(self):

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -93,7 +93,7 @@ class RequestModelFactory(object):
             except KeyError:
                 pass
 
-        return json.dumps(headers, cls=DefaultEncoder)
+        return json.dumps(headers, cls=DefaultEncoder, ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)
 
     def _mask_credentials(self, body):
         """
@@ -127,7 +127,7 @@ class RequestModelFactory(object):
             except Exception:
                 Logger.debug('{}'.format(str(e)))
         else:
-            body = json.dumps(replace_pattern_values(json_body))
+            body = json.dumps(replace_pattern_values(json_body), ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)
 
         return body
 
@@ -139,10 +139,12 @@ class RequestModelFactory(object):
         body = ''
         if content_type in content_type_form:
             body = self.request.POST
-            body = json.dumps(dict(body), sort_keys=True, indent=4)
+            body = json.dumps(dict(body), sort_keys=True, indent=4
+                              , ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)
         elif content_type in content_types_json:
             try:
-                body = json.dumps(json.loads(raw_body), sort_keys=True, indent=4)
+                body = json.dumps(json.loads(raw_body), sort_keys=True, indent=4
+                                  , ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)
             except:
                 body = raw_body
         return body
@@ -212,7 +214,7 @@ class RequestModelFactory(object):
         encoded_query_params = ''
         if query_params:
             query_params_dict = dict(zip(query_params.keys(), query_params.values()))
-            encoded_query_params = json.dumps(query_params_dict)
+            encoded_query_params = json.dumps(query_params_dict, ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)
         return encoded_query_params
 
     def view_name(self):
@@ -285,7 +287,8 @@ class ResponseModelFactory(object):
                     # and json.dumps(...) in python3
                     content = content.decode()
                 try:
-                    body = json.dumps(json.loads(content), sort_keys=True, indent=4)
+                    body = json.dumps(json.loads(content), sort_keys=True, indent=4
+                                      , ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)
                 except (TypeError, ValueError):
                     Logger.warn(
                         'Response to request with pk %s has content type %s but was unable to parse it'
@@ -312,7 +315,7 @@ class ResponseModelFactory(object):
         silky_response = models.Response.objects.create(
             request_id=self.request.id,
             status_code=self.response.status_code,
-            encoded_headers=json.dumps(headers),
+            encoded_headers=json.dumps(headers, ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII),
             body=b
         )
 

--- a/silk/utils/data_deletion.py
+++ b/silk/utils/data_deletion.py
@@ -22,7 +22,7 @@ def delete_model(model):
     # oracle doesn't provide good support for disabling foreign key checks
     while True:
         items_to_delete = list(
-            model.objects.values_list('pk', flat=True).all()[:1000])
+            model.objects.values_list('pk', flat=True).all()[:800])
         if not items_to_delete:
             break
         model.objects.filter(pk__in=items_to_delete).delete()


### PR DESCRIPTION
Support for users to configure the ```SILKY_JSON_ENSURE_ASCII``` parameter to implement ```json.dumps``` support Chinese