### PR TITLE
Fix force_text RemovedInDjango40Warning

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -6,7 +6,6 @@ import traceback
 import base64
 from uuid import UUID
 
-from django.utils.encoding import force_text
 from django.urls import resolve, Resolver404
 
 from silk import models
@@ -317,7 +316,8 @@ class ResponseModelFactory(object):
         )
 
         try:
-            silky_response.raw_body = force_text(base64.b64encode(content))
+            raw_body = base64.b64encode(content)
         except TypeError:
-            silky_response.raw_body = force_text(base64.b64encode(content.encode('utf-8')))
+            raw_body = base64.b64encode(content.encode('utf-8'))
+        silky_response.raw_body = raw_body.decode('ascii')
         return silky_response


### PR DESCRIPTION
The result of base64.b64encode can be ASCII decoded.