### PR TITLE
Make compatible with Django 3.1

### DIFF
--- a/silk/sql.py
+++ b/silk/sql.py
@@ -1,7 +1,7 @@
 import logging
 import traceback
 
-from django.db.models.sql import EmptyResultSet
+from django.core.exceptions import EmptyResultSet
 from django.utils import timezone
 
 from silk.collector import DataCollector

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ python =
 DJANGO =
     2.2: django22
     3.0: django30
+    3.1: django31
     master: djangomaster
 DATABASE =
     sqlite3: sqlite3
@@ -18,7 +19,7 @@ DATABASE =
 [tox]
 envlist =
     py{35}-django{22}-{sqlite3,mysql,postgresql}
-    py{36,37,38,py3}-django{22,30,master}-{sqlite3,mysql,postgresql}
+    py{36,37,38,py3}-django{22,30,31,master}-{sqlite3,mysql,postgresql}
 
 [testenv]
 changedir = {toxinidir}/project
@@ -28,6 +29,7 @@ deps =
     postgresql: psycopg2
     django22: django>=2.2,<2.3
     django30: django>=3.0,<3.1
+    django31: django>=3.1,<3.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 setenv =
     PYTHONPATH={toxinidir}:{toxinidir}


### PR DESCRIPTION
Fixes #431 and makes django-silk compatible with Django 3.1 (released today).