### PR TITLE
#427 Passed WSGI request to SILKY_PYTHON_PROFILER_FUNC

### DIFF
--- a/silk/collector.py
+++ b/silk/collector.py
@@ -86,17 +86,9 @@ class DataCollector(metaclass=Singleton):
     def profiles(self):
         return self._get_objects(TYP_PROFILES)
 
-    def configure(self, request=None):
-        silky_config = SilkyConfig()
-
+    def configure(self, request=None, should_profile=True):
         self.request = request
         self._configure()
-
-        if silky_config.SILKY_PYTHON_PROFILER_FUNC:
-            should_profile = silky_config.SILKY_PYTHON_PROFILER_FUNC(request)
-        else:
-            should_profile = silky_config.SILKY_PYTHON_PROFILER
-
         if should_profile:
             self.local.pythonprofiler = cProfile.Profile()
             self.local.pythonprofiler.enable()

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -104,8 +104,15 @@ class SilkyMiddleware:
         if not hasattr(SQLCompiler, '_execute_sql'):
             SQLCompiler._execute_sql = SQLCompiler.execute_sql
             SQLCompiler.execute_sql = execute_sql
+
+        silky_config = SilkyConfig()
+
+        should_profile = silky_config.SILKY_PYTHON_PROFILER
+        if silky_config.SILKY_PYTHON_PROFILER_FUNC:
+            should_profile = silky_config.SILKY_PYTHON_PROFILER_FUNC(request)
+
         request_model = RequestModelFactory(request).construct_request_model()
-        DataCollector().configure(request_model)
+        DataCollector().configure(request_model, should_profile=should_profile)
 
     @transaction.atomic()
     def _process_response(self, request, response):


### PR DESCRIPTION
In django-silk==4.0.1 function `SILKY_PYTHON_PROFILER_FUNC ` is getting an instance of silk.models.Request instead if WSGI request which means there's no access to the session, authenticated user, etc.

connects: https://github.com/jazzband/django-silk/issues/427