### PR TITLE
Added Django 3.1 to Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
   - DJANGO=3.0 DATABASE=sqlite3
   - DJANGO=3.0 DATABASE=mysql
   - DJANGO=3.0 DATABASE=postgresql
+  - DJANGO=3.1 DATABASE=sqlite3
+  - DJANGO=3.1 DATABASE=mysql
+  - DJANGO=3.1 DATABASE=postgresql
 jobs:
   exclude:
     - python: 3.5
@@ -30,6 +33,12 @@ jobs:
       env: DJANGO=3.0 DATABASE=mysql
     - python: 3.5
       env: DJANGO=3.0 DATABASE=postgresql
+    - python: 3.5
+      env: DJANGO=3.1 DATABASE=sqlite3
+    - python: 3.5
+      env: DJANGO=3.1 DATABASE=mysql
+    - python: 3.5
+      env: DJANGO=3.1 DATABASE=postgresql
   include:
     - stage: deploy
       env:


### PR DESCRIPTION
#433 added Django 3.1 to the tox matrix. The test matrix for TravisCI is held in a separate file and so also needs updating. 👍 