### PR TITLE
Do not crash when silk app is not included in urls

### DIFF
--- a/project/tests/test_silky_middleware.py
+++ b/project/tests/test_silky_middleware.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from mock import patch, Mock
 
 from silk.config import SilkyConfig
@@ -113,6 +113,12 @@ class TestShouldIntercept(TestCase):
         should_intercept = _should_intercept(request)
 
         self.assertFalse(should_intercept)
+
+    @override_settings(ROOT_URLCONF='tests.urlconf_without_silk')
+    def test_should_intercept_without_silk_urls(self):
+        request = Request()
+        request.path = '/login'
+        _should_intercept(request)  # Just checking no crash
 
     def test_should_intercept_ignore_paths(self):
         SilkyConfig().SILKY_IGNORE_PATHS = [

--- a/project/tests/urlconf_without_silk.py
+++ b/project/tests/urlconf_without_silk.py
@@ -1,0 +1,9 @@
+from django.conf.urls import include, url
+
+
+urlpatterns = [
+    url(
+        r'^example_app/',
+        include('example_app.urls', namespace='example_app')
+    ),
+]

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -43,7 +43,11 @@ def _should_intercept(request):
         if random.random() > config.SILKY_INTERCEPT_PERCENT / 100.0:
             return False
 
-    silky = request.path.startswith(get_fpath())
+    try:
+        silky = request.path.startswith(get_fpath())
+    except NoReverseMatch:
+        silky = False
+
     ignored = request.path in config.SILKY_IGNORE_PATHS
     return not (silky or ignored)
 


### PR DESCRIPTION
Hi,

Right now `SilkyMiddleware` raises `NoReverseMatch` when `silk.urls` are not included in the app. There are various reasons when one _might not_ want to enable the Silk UI, but still keep the middleware around. For example, to disable Silk in production, the easiest way would be to set `SILKY_INTERCEPT_PERCENT` to 0, and not include the URLs. Unless there's a reason to keep the exception in place, I'd like to have Silk handle this gracefully.

This is my first time posting here, so I'm not too familiar with the development process. Happy to address any feedback.

Thanks