### PR TITLE
parse query when counting joins

### DIFF
--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -347,13 +347,22 @@ class SQLQueryTest(TestCase):
         self.obj.query = query
         self.assertEqual(self.obj.num_joins, 4)
 
-    # FIXME bug, not a feature
     def test_num_joins_if_no_joins_in_query_but_this_word_searched(self):
 
         query = """SELECT Book.title FROM  Book WHERE Book.title=`Join the dark side, Luke!`;"""
 
         self.obj.query = query
-        self.assertEqual(self.obj.num_joins, 1)
+        self.assertEqual(self.obj.num_joins, 0)
+
+    def test_num_joins_if_multiple_statement_in_query(self):
+        query = """SELECT Book.title FROM  Book WHERE Book.title=`Join the dark side, Luke!`;
+                   SELECT Book.joiner FROM Book
+                    LEFT OUTER JOIN joined ON Book.joiner = joined.joiner
+                    INNER JOIN joined ON Book.joiner = joined.joiner
+                   WHERE Book.joiner='Join i am'"""
+
+        self.obj.query = query
+        self.assertEqual(self.obj.num_joins, 2)
 
     def test_tables_involved_if_no_query(self):
 

--- a/silk/models.py
+++ b/silk/models.py
@@ -252,10 +252,13 @@ class SQLQuery(models.Model):
     def formatted_query(self):
         return sqlparse.format(self.query, reindent=True, keyword_case='upper')
 
-    # TODO: Surely a better way to handle this? May return false positives
     @property
     def num_joins(self):
-        return self.query.lower().count('join ')
+        parsed_query  = sqlparse.parse(self.query)
+        count = 0
+        for statement in parsed_query:
+            count += sum(map(lambda t: t.match(sqlparse.tokens.Keyword, r'\.*join\.*', regex=True), statement.flatten()))
+        return count
 
     @property
     def tables_involved(self):


### PR DESCRIPTION
This PR modifies the `num_joins` logic, instead of counting the occurences of the string `join` it parses the query in order to exclude all the tokens that are not SQL Keyword such as column Identifiers or String Literals.
This can be useful in order to avoid false positives