### PR TITLE
Add remote storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,14 @@ To enable query analysis when supported by the dbms a config var can be set in o
 SILKY_ANALYZE_QUERIES = True
 ```
 
+### Set profile filename prefix
+
+Allow to set a prefix to the profile filename
+
+```python
+SILKY_PROF_FILE_PREFIX = "prof/"
+```
+
 ### Clearing logged data
 
 A management command will wipe out all logged data:

--- a/silk/collector.py
+++ b/silk/collector.py
@@ -3,6 +3,9 @@ from threading import local
 import cProfile
 import pstats
 import logging
+import marshal
+
+from django.core.files.base import ContentFile
 
 from io import StringIO
 
@@ -146,9 +149,9 @@ class DataCollector(metaclass=Singleton):
 
             if SilkyConfig().SILKY_PYTHON_PROFILER_BINARY:
                 file_name = self.request.prof_file.storage.get_available_name("{}.prof".format(str(self.request.id)))
-                with open(self.request.prof_file.storage.path(file_name), 'w+b') as f:
-                    ps.dump_stats(f.name)
-                self.request.prof_file = f.name
+                content = ContentFile(marshal.dumps(ps.stats))
+                saved_path = self.request.prof_file.storage.save(file_name, content)
+                self.request.prof_file = saved_path
                 self.request.save()
 
         sql_queries = []

--- a/silk/config.py
+++ b/silk/config.py
@@ -30,7 +30,8 @@ class SilkyConfig(metaclass=Singleton):
         'SILKY_STORAGE_CLASS': 'silk.storage.ProfilerResultStorage',
         'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware',
         'SILKY_JSON_ENSURE_ASCII': True,
-        'SILKY_ANALYZE_QUERIES': False
+        'SILKY_ANALYZE_QUERIES': False,
+        'SILKY_PROF_FILE_PREFIX': '',
     }
 
     def _setup(self):


### PR DESCRIPTION
Some years ago i had to hack a solution to add support for remote storage.
The years goes on and now i have to update django silk to support last release of Django and in consequence my customization.

I see there is an issue #208 and a proposed solution #209 but it does not seems to have a lot of traction.

I wonder if you are interested to support this functionality and after some refine of my hack i made this pr.

The following changes are introduced:
1. Add support for remote storages by using django storage interface
2. Add the settings `SILKY_PROF_FILE_PREFIX` to allow set a prefix
3. Add request path to the profile file path

The 2nd point was necessary in my implementation to use the same remote storage with different version of the code while the 3rd is just a small improvement to retrieve more easily the profile files of the same request.