### PR TITLE
Fix transaction error for mysql

### DIFF
--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -43,7 +43,8 @@ DATABASES = {
         "USER": os.environ.get("DB_USER", 'postgres'),
         "PASSWORD": os.environ.get("DB_PASSWORD", "postgres"),
         "HOST": os.environ.get("DB_HOST", "127.0.0.1"),
-        "PORT": os.environ.get("DB_PORT", 5432)
+        "PORT": os.environ.get("DB_PORT", 5432),
+        "ATOMIC_REQUESTS": True
     },
 }
 

--- a/project/tests/test_view_clear_db.py
+++ b/project/tests/test_view_clear_db.py
@@ -1,0 +1,20 @@
+from .factories import RequestMinFactory
+from django.test import TestCase
+from silk.config import SilkyConfig
+from silk.middleware import silky_reverse
+from silk import models
+
+
+class TestViewClearDB(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestViewClearDB, cls).setUpClass()
+        SilkyConfig().SILKY_AUTHENTICATION = False
+        SilkyConfig().SILKY_AUTHORISATION = False
+
+    def test_clear_all(self):
+        RequestMinFactory.create()
+        self.assertEqual(models.Request.objects.count(), 1)
+        response = self.client.post(silky_reverse("cleardb"), {"clear_all": "on"})
+        self.assertTrue(response.status_code == 200)
+        self.assertEqual(models.Request.objects.count(), 0)

--- a/silk/views/clear_db.py
+++ b/silk/views/clear_db.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import View
@@ -7,6 +8,7 @@ from silk.models import Request, Response, SQLQuery, Profile
 from silk.utils.data_deletion import delete_model
 
 
+@method_decorator(transaction.non_atomic_requests, name="dispatch")
 class ClearDBView(View):
 
     @method_decorator(login_possibly_required)


### PR DESCRIPTION
For mysql, if `ATOMIC_REQUESTS` was enabled, `truncate` will cause an error saying `SAVEPOINT does not exist`.
So we should exempt transaction for clear_db view. 