### PR TITLE
fix: DataCollector sql_queries model not found on filter(request=self…

### DIFF
--- a/silk/collector.py
+++ b/silk/collector.py
@@ -157,9 +157,8 @@ class DataCollector(metaclass=Singleton):
             sql_query = models.SQLQuery(**query)
             sql_queries += [sql_query]
 
-        models.SQLQuery.objects.bulk_create(sql_queries)
-        sql_queries = models.SQLQuery.objects.filter(request=self.request)
-        for sql_query in sql_queries.all():
+        sql_queries = models.SQLQuery.objects.bulk_create(sql_queries)
+        for sql_query in sql_queries:
             query = self.queries.get(sql_query.identifier)
             if query:
                 query['model'] = sql_query


### PR DESCRIPTION
Closes #475 

After digging into silk DataCollector, I figured out in the second line of this section of the code no sql query is returned. So the part where adds model to query dictionaries, can't do it's job and we face the error issued in #475 
```
models.SQLQuery.objects.bulk_create(sql_queries)
sql_queries = models.SQLQuery.objects.filter(request=self.request)
```  

By changing these 2 lines to `sql_queries = models.SQLQuery.objects.bulk_create(sql_queries)`, sql_queries is no longer empty and the rest of the system can function correctly. 
