### PR TITLE
Don't return null values when computing "Most Time Overall" summary

### DIFF
--- a/silk/views/summary.py
+++ b/silk/views/summary.py
@@ -31,7 +31,7 @@ class SummaryView(View):
         for view_name, _ in values_list:
             request = models.Request.objects.filter(view_name=view_name, *filters).filter(time_taken__isnull=False).order_by('-time_taken')[0]
             requests.append(request)
-        return requests
+        return sorted(requests, key=lambda item: item.time_taken, reverse=True)
 
     def _time_spent_in_db_by_view(self, filters):
         values_list = models.Request.objects.filter(*filters).values_list('view_name').annotate(t=Sum('queries__time_taken')).filter(t__gte=0).order_by('-t')[:5]

--- a/silk/views/summary.py
+++ b/silk/views/summary.py
@@ -26,10 +26,10 @@ class SummaryView(View):
 
     # TODO: Find a more efficient way to do this. Currently has to go to DB num. views + 1 times and is prob quite expensive
     def _longest_query_by_view(self, filters):
-        values_list = models.Request.objects.filter(*filters).values_list("view_name").annotate(max=Max('time_taken')).order_by('-max')[:5]
+        values_list = models.Request.objects.filter(*filters).values_list("view_name").annotate(max=Max('time_taken')).filter(max__isnull=False).order_by('-max')[:5]
         requests = []
         for view_name, _ in values_list:
-            request = models.Request.objects.filter(view_name=view_name, *filters).order_by('-time_taken')[0]
+            request = models.Request.objects.filter(view_name=view_name, *filters).filter(time_taken__isnull=False).order_by('-time_taken')[0]
             requests.append(request)
         return requests
 


### PR DESCRIPTION
This PR aims to fix a bug where this summary could return a list of empty timing values if there are null values in the `time_taken` field.