### PR TITLE
 Don't return null values when computing "Most Time Overall" summary

### DIFF
--- a/silk/views/summary.py
+++ b/silk/views/summary.py
@@ -37,7 +37,7 @@ class SummaryView(View):
         values_list = models.Request.objects.filter(*filters).values_list('view_name').annotate(t=Sum('queries__time_taken')).filter(t__gte=0).order_by('-t')[:5]
         requests = []
         for view, _ in values_list:
-            r = models.Request.objects.filter(view_name=view, *filters).annotate(t=Sum('queries__time_taken')).order_by('-t')[0]
+            r = models.Request.objects.filter(view_name=view, *filters).annotate(t=Sum('queries__time_taken')).filter(t__isnull=False).order_by('-t')[0]
             requests.append(r)
         return requests
 

--- a/silk/views/summary.py
+++ b/silk/views/summary.py
@@ -39,7 +39,7 @@ class SummaryView(View):
         for view, _ in values_list:
             r = models.Request.objects.filter(view_name=view, *filters).annotate(t=Sum('queries__time_taken')).filter(t__isnull=False).order_by('-t')[0]
             requests.append(r)
-        return requests
+        return sorted(requests, key=lambda item: item.t, reverse=True)
 
     def _num_queries_by_view(self, filters):
         queryset = models.Request.objects.filter(*filters).values_list('view_name').annotate(t=Count('queries')).order_by('-t')[:5]


### PR DESCRIPTION
This PR aims to fix a bug where this summary could return a list of empty timing values if there are null values in the queries__time_taken field.