### PR TITLE
Ensure sorting between most db queries requests

### DIFF
--- a/silk/views/summary.py
+++ b/silk/views/summary.py
@@ -51,7 +51,7 @@ class SummaryView(View):
                 requests.append(r)
             except IndexError:
                 pass
-        return requests
+        return sorted(requests, key=lambda item: item.t, reverse=True)
 
     def _create_context(self, request):
         raw_filters = request.session.get(self.filters_key, {})


### PR DESCRIPTION
This PR ensures that the result in the "Most Database Queries" is actually sorted in descending order. The previous code could result in the results being out of order since the ordering was applied seperately per view_name.