### PR TITLE
Fix egg metadata error

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can install from master using the following, but please be aware that the ve
 may not be working for all versions specified in [requirements](#requirements)
 
 ```bash
-pip install -e git+https://github.com/jazzband/django-silk.git#egg=silk
+pip install -e git+https://github.com/jazzband/django-silk.git#egg=django-silk
 ```
 
 ## Features


### PR DESCRIPTION
The current instructions in the readme regarding alternative installation methods states to use `pip install -e git+https://github.com/jazzband/django-silk.git#egg=silk`. However, this is incorrect and will result in the following error:

```bash
Obtaining silk from git+https://github.com/jazzband/django-silk.git#egg=silk
  Cloning https://github.com/jazzband/django-silk.git to c:\users\username\repositories\conreq\.venv\src\silk
  Running command git clone -q https://github.com/jazzband/django-silk.git 'c:\users\username\repositories\conreq\.venv\src\silk'
  WARNING: Generating metadata for package silk produced metadata for project name django-silk. Fix your #egg=silk fragments.
WARNING: Discarding git+https://github.com/jazzband/django-silk.git#egg=silk. Requested django-silk from git+https://github.com/jazzband/django-silk.git#egg=silk has inconsistent name: filename has 'silk', but metadata has 'django-silk'
ERROR: Could not find a version that satisfies the requirement silk (unavailable) (from versions: none)
ERROR: No matching distribution found for silk (unavailable)
```
This PR changes the instructions to use `pip install -e git+https://github.com/jazzband/django-silk.git#egg=django-silk`