### PR TITLE
Fixed a bug that the profile tab could not be opened when the source …

### DIFF
--- a/silk/views/code.py
+++ b/silk/views/code.py
@@ -10,7 +10,7 @@ def _code(file_path, line_num, end_line_num=None):
     end_line_num = int(end_line_num)
     actual_line = []
     lines = ''
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         r = range(max(0, line_num - 10), line_num + 10)
         for i, line in enumerate(f):
             if i in r:


### PR DESCRIPTION
There was a bug that the profile tab could not be opened when the source code contained Japanese. The error message is as follows.

'cp932' codec can't decode byte 0x88 in position 19: illegal multibyte sequence

Obviously, it is due to a character code problem.
Basically, the source code should be written in UTF-8, so I explicitly specified to read it in utf-8.