### PR TITLE
Add tests that access the actual DB

### DIFF
--- a/project/tests/factories.py
+++ b/project/tests/factories.py
@@ -4,6 +4,8 @@ import factory.fuzzy
 
 from silk.models import Request, Response, SQLQuery
 
+from example_app.models import Blind
+
 
 HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'HEAD', 'OPTIONS']
 STATUS_CODES = [200, 201, 300, 301, 302, 401, 403, 404]
@@ -33,3 +35,12 @@ class ResponseFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Response
+
+
+class BlindFactory(factory.django.DjangoModelFactory):
+    name = factory.Faker('pystr', min_chars=5, max_chars=10)
+    child_safe = factory.Faker('pybool')
+    photo = factory.django.ImageField()
+
+    class Meta:
+        model = Blind

--- a/project/tests/test_db.py
+++ b/project/tests/test_db.py
@@ -1,0 +1,56 @@
+"""
+Test profiling of DB queries without mocking, to catch possible
+incompatibility
+"""
+from django.shortcuts import reverse
+from django.test import Client, TestCase
+from silk.collector import DataCollector
+from silk.config import SilkyConfig
+from silk.models import Request
+from silk.profiling.profiler import silk_profile
+
+from .factories import BlindFactory
+
+
+class TestDbQueries(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        objects = BlindFactory.create_batch(size=5)
+        SilkyConfig().SILKY_META = False
+
+    def test_profile_request_to_db(self):
+        client = Client()
+        DataCollector().configure(Request(reverse('example_app:index')))
+
+        with silk_profile(name='test_profile'):
+            resp = client.get(reverse('example_app:index'))
+
+        profile = list(DataCollector().profiles.values())[0]
+        assert len(resp.context['blinds']) == 5
+
+
+class TestAnalyzeQueries(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        objects = BlindFactory.create_batch(size=5)
+        SilkyConfig().SILKY_META = False
+        SilkyConfig().SILKY_ANALYZE_QUERIES = True
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        SilkyConfig().SILKLY_ANALYZE_QUERIES = False
+
+    def test_analyze_queries(self):
+        DataCollector().configure(Request(reverse('example_app:index')))
+        client = Client()
+
+        with silk_profile(name='test_profile'):
+            resp = client.get(reverse('example_app:index'))
+
+        profile = list(DataCollector().profiles.values())[0]
+        assert len(resp.context['blinds']) == 5
+


### PR DESCRIPTION
The project's existing tests all seem to mock DB access, unless I'm missing something. This PR adds some simple tests that actually access the DB. This allows us to actually catch compatibility errors like those in #489 ,

Let me know what you think.