### PR TITLE
Make sensitive keys set configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,21 @@ To enable query analysis when supported by the dbms a config var can be set in o
 SILKY_ANALYZE_QUERIES = True
 ```
 
+### Masking sensitive data on request body
+
+By default, Silk is filtering values that are under the following keys
+
+```python
+SILKY_SENSITIVE_KEYS = {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}
+```
+
+This means that values that contains above keys (it is case insensitive), will be masked when being logged. But sometimes, you might want to have your own sensitive keywords, then above configuration can be modified
+
+```python
+SILKY_SENSITIVE_KEYS = {'custom-password'}
+```
+
+
 ### Clearing logged data
 
 A management command will wipe out all logged data:

--- a/README.md
+++ b/README.md
@@ -490,13 +490,13 @@ SILKY_ANALYZE_QUERIES = True
 
 ### Masking sensitive data on request body
 
-By default, Silk is filtering values that are under the following keys
+By default, Silk is filtering values that are under that contains the following keys (they are case insensitive)
 
 ```python
 SILKY_SENSITIVE_KEYS = {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}
 ```
 
-This means that values that contains above keys (it is case insensitive), will be masked when being logged. But sometimes, you might want to have your own sensitive keywords, then above configuration can be modified
+But sometimes, you might want to have your own sensitive keywords, then above configuration can be modified
 
 ```python
 SILKY_SENSITIVE_KEYS = {'custom-password'}

--- a/silk/config.py
+++ b/silk/config.py
@@ -30,7 +30,8 @@ class SilkyConfig(metaclass=Singleton):
         'SILKY_STORAGE_CLASS': 'silk.storage.ProfilerResultStorage',
         'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware',
         'SILKY_JSON_ENSURE_ASCII': True,
-        'SILKY_ANALYZE_QUERIES': False
+        'SILKY_ANALYZE_QUERIES': False,
+        'SILKY_SENSITIVE_KEYS': {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}
     }
 
     def _setup(self):

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -109,7 +109,7 @@ class RequestModelFactory(object):
         """
         Mask credentials of potentially sensitive info before saving to db.
         """
-        sensitive_keys = {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}
+        sensitive_keys = SilkyConfig().SILKY_SENSITIVE_KEYS
         key_string = '|'.join(sensitive_keys)
 
         def replace_pattern_values(obj):


### PR DESCRIPTION
Currently the masking logic has hard coded set of sensitive keys under RequestModelFactory to mask the body value. There are times where I need to add values into the existing keys. It is hard with the current implementation.

Since the masking logic is already implemented, it would be nice to have the sensitive keys configurable from Django settings. This will make the masking more flexible for many users.

For this I create a new key in config
`SILKY_SENSITIVE_KEYS `

with default value
`{'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}`
so it does not affect any previous users.

Let me know if this is a good addition