### PR TITLE
`apps.py` added with `default_auto_field` set

### DIFF
--- a/project/tests/test_app_config.py
+++ b/project/tests/test_app_config.py
@@ -1,0 +1,14 @@
+from django.apps import apps as proj_apps
+from django.test import TestCase
+
+from silk.apps import SilkAppConfig
+
+
+class TestAppConfig(TestCase):
+    """
+    Test if correct AppConfig class is loaded by Django.
+    """
+
+    def test_app_config_loaded(self):
+        silk_app_config = proj_apps.get_app_config("silk")
+        self.assertIsInstance(silk_app_config, SilkAppConfig)

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -505,11 +505,10 @@ class NoPendingMigrationsTest(TestCase):
     @override_settings(DEFAULT_AUTO_FIELD='django.db.models.BigAutoField')
     def test_check_with_overridden_default_auto_field(self):
         """
-        This is to test that no migrations are pending with `BigAutoField`
-        set as `DEFAULT_AUTO_FIELD` - which is default when generating proj
-        with Django 3.2.
+        Test with `BigAutoField` set as `DEFAULT_AUTO_FIELD` - which is
+        default when generating proj with Django 3.2.
         """
-        call_command("makemigrations", "silk", "--check", "--dry-run")
+        self.test_no_pending_migrations()
 
 
 class BaseProfileTest(TestCase):

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -3,6 +3,7 @@ import datetime
 import uuid
 import pytz
 
+from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
@@ -489,6 +490,15 @@ class SQLQueryTest(TestCase):
         self.obj.delete()
 
         self.assertNotIn(self.obj, models.SQLQuery.objects.all())
+
+
+class NoPendingMigrationsTest(TestCase):
+    """
+    Test if proper migrations are added the models state is consistent
+    """
+
+    def test_makemigrations_check(self):
+        call_command("makemigrations", "silk", "--check", "--dry-run")
 
 
 class BaseProfileTest(TestCase):

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -4,7 +4,7 @@ import uuid
 import pytz
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 
@@ -494,10 +494,19 @@ class SQLQueryTest(TestCase):
 
 class NoPendingMigrationsTest(TestCase):
     """
-    Test if proper migrations are added the models state is consistent
+    Test if proper migrations are added and the models state is consistent.
     """
 
-    def test_makemigrations_check(self):
+    def test_no_pending_migrations(self):
+        call_command("makemigrations", "silk", "--check", "--dry-run")
+
+    @override_settings(DEFAULT_AUTO_FIELD='django.db.models.BigAutoField')
+    def test_check_with_overridden_default_auto_field(self):
+        """
+        This is to test that no migrations are pending with `BigAutoField`
+        set as `DEFAULT_AUTO_FIELD` - which is default when generating proj
+        with Django 3.2.
+        """
         call_command("makemigrations", "silk", "--check", "--dry-run")
 
 

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -495,6 +495,8 @@ class SQLQueryTest(TestCase):
 class NoPendingMigrationsTest(TestCase):
     """
     Test if proper migrations are added and the models state is consistent.
+    It should make sure that no new migrations are created for this app,
+    when end-user runs `makemigrations` command.
     """
 
     def test_no_pending_migrations(self):

--- a/silk/__init__.py
+++ b/silk/__init__.py
@@ -4,3 +4,6 @@ try:
     __version__ = get_distribution("django-silk").version
 except DistributionNotFound:
     pass
+
+# set default_app_config
+default_app_config = 'silk.apps.SilkAppConfig'

--- a/silk/apps.py
+++ b/silk/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class SilkAppConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
+    name = 'silk'


### PR DESCRIPTION
This is to avoid unnecessary migrations caused by default "id" field type change from `AutoField` -> `BigAutoField` in Django 3.2.


new test added
  - testing if proper AppConfig class is loaded by Django
  - testing if package has no pending migrations and will not generate new migrations when running `makemigrations` on user-end.