### PR TITLE
explicit "id" fields to `SQLQuery` and `Profile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ urlpatterns += [url(r'^silk/', include('silk.urls', namespace='silk'))]
 before running migrate:
 
 ```bash
-python manage.py makemigrations
-
 python manage.py migrate
 
 python manage.py collectstatic

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -3,7 +3,8 @@ import datetime
 import uuid
 import pytz
 
-from django.test import TestCase
+from django.core.management import call_command
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 
@@ -489,6 +490,25 @@ class SQLQueryTest(TestCase):
         self.obj.delete()
 
         self.assertNotIn(self.obj, models.SQLQuery.objects.all())
+
+
+class NoPendingMigrationsTest(TestCase):
+    """
+    Test if proper migrations are added and the models state is consistent.
+    It should make sure that no new migrations are created for this app,
+    when end-user runs `makemigrations` command.
+    """
+
+    def test_no_pending_migrations(self):
+        call_command("makemigrations", "silk", "--check", "--dry-run")
+
+    @override_settings(DEFAULT_AUTO_FIELD='django.db.models.BigAutoField')
+    def test_check_with_overridden_default_auto_field(self):
+        """
+        Test with `BigAutoField` set as `DEFAULT_AUTO_FIELD` - which is
+        default when generating proj with Django 3.2.
+        """
+        self.test_no_pending_migrations()
 
 
 class BaseProfileTest(TestCase):

--- a/silk/migrations/0009_explicit_id_fields.py
+++ b/silk/migrations/0009_explicit_id_fields.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('silk', '0008_sqlquery_analysis'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='profile',
+            name='id',
+            field=models.AutoField(primary_key=True, serialize=False),
+        ),
+        migrations.AlterField(
+            model_name='sqlquery',
+            name='id',
+            field=models.AutoField(primary_key=True, serialize=False),
+        ),
+    ]

--- a/silk/models.py
+++ b/silk/models.py
@@ -231,6 +231,7 @@ class SQLQueryManager(models.Manager):
 
 
 class SQLQuery(models.Model):
+    id = models.AutoField(primary_key=True)
     query = TextField()
     start_time = DateTimeField(null=True, blank=True, default=timezone.now)
     end_time = DateTimeField(null=True, blank=True)
@@ -330,6 +331,7 @@ class BaseProfile(models.Model):
 
 
 class Profile(BaseProfile):
+    id = models.AutoField(primary_key=True)
     file_path = CharField(max_length=300, blank=True, default='')
     line_num = IntegerField(null=True, blank=True)
     end_line_num = IntegerField(null=True, blank=True)


### PR DESCRIPTION
This is to avoid unnecessary migration files created inside package by user when running `makemigrations` - becasuse after Django 3.2 "default id field" is configurable project wide by user with `DEFAULT_AUTO_FIELD`.

Also test for checking pending migration added.