### PR TITLE
Fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ MIDDLEWARE = [
 
 INSTALLED_APPS = (
     ...
-    'silk.apps.SilkAppConfig'
+    'silk'
 )
 ```
 


### PR DESCRIPTION
Right now, instructions in README seem to be a bit inconsistent - code is [checking](https://github.com/jazzband/django-silk/blob/12a28e99ec0c629aeb379b0657ebfc56925f8d61/silk/profiling/profiler.py#L125) for `silk` being added to `INSTALLED_APPS` setting, and the README says about adding `silk.apps.SilkAppConfig` there.