### PR TITLE
Replace assertDictContainsSubset

### DIFF
--- a/project/tests/test_dynamic_profiling.py
+++ b/project/tests/test_dynamic_profiling.py
@@ -9,8 +9,8 @@ from silk.profiling.dynamic import (
     profile_function_or_method,
 )
 
-from .util import mock_data_collector
 from .test_lib.assertion import dict_contains
+from .util import mock_data_collector
 
 
 class TestGetModule(TestCase):

--- a/project/tests/test_dynamic_profiling.py
+++ b/project/tests/test_dynamic_profiling.py
@@ -10,6 +10,7 @@ from silk.profiling.dynamic import (
 )
 
 from .util import mock_data_collector
+from .test_lib.assertion import dict_contains
 
 
 class TestGetModule(TestCase):
@@ -72,13 +73,13 @@ class TestProfileFunction(TestCase):
                 MyClass().foo()
                 self.assertEqual(mock_DataCollector.return_value.register_profile.call_count, 1)
                 call_args = mock_DataCollector.return_value.register_profile.call_args[0][0]
-                self.assertDictContainsSubset({
+                self.assertTrue(dict_contains({
                     'func_name': foo.__name__,
                     'dynamic': True,
                     'file_path': source_file_name(),
                     'name': 'test',
                     'line_num': foo.__code__.co_firstlineno
-                }, call_args)
+                }, call_args))
 
     def test_func_as_str(self):
         name = foo.__name__
@@ -89,10 +90,10 @@ class TestProfileFunction(TestCase):
             foo()
             self.assertEqual(mock_DataCollector.return_value.register_profile.call_count, 1)
             call_args = mock_DataCollector.return_value.register_profile.call_args[0][0]
-            self.assertDictContainsSubset({
+            self.assertTrue(dict_contains({
                 'func_name': name,
                 'dynamic': True,
                 'file_path': source_file_name(),
                 'name': 'test',
                 'line_num': line_num
-            }, call_args)
+            }, call_args))

--- a/project/tests/test_lib/assertion.py
+++ b/project/tests/test_lib/assertion.py
@@ -1,0 +1,7 @@
+def dict_contains(child_dict, parent_dict):
+    for key, value in child_dict.items():
+        if key not in parent_dict:
+            return False
+        if parent_dict[key] != value:
+            return False
+    return True

--- a/project/tests/test_view_profiling.py
+++ b/project/tests/test_view_profiling.py
@@ -4,8 +4,8 @@ from django.test import TestCase
 
 from silk.views.profiling import ProfilingView
 
-from .test_lib.mock_suite import MockSuite
 from .test_lib.assertion import dict_contains
+from .test_lib.mock_suite import MockSuite
 
 
 class TestProfilingViewDefaults(TestCase):

--- a/project/tests/test_view_profiling.py
+++ b/project/tests/test_view_profiling.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from silk.views.profiling import ProfilingView
 
 from .test_lib.mock_suite import MockSuite
+from .test_lib.assertion import dict_contains
 
 
 class TestProfilingViewDefaults(TestCase):
@@ -59,13 +60,13 @@ class TestProfilingContext(TestCase):
         request.GET = {}
         request.session = {}
         context = ProfilingView()._create_context(request)
-        self.assertDictContainsSubset({
+        self.assertTrue(dict_contains({
             'show': ProfilingView.default_show,
             'order_by': ProfilingView.defualt_order_by,
             'options_show': ProfilingView.show,
             'options_order_by': ProfilingView.order_by,
             'options_func_names': ProfilingView()._get_function_names()
-        }, context)
+        }, context))
         self.assertNotIn('path', context)
         self.assertIn('results', context)
 
@@ -81,7 +82,7 @@ class TestProfilingContext(TestCase):
                        'name': name,
                        'order_by': order_by}
         context = ProfilingView()._create_context(request)
-        self.assertDictContainsSubset({
+        self.assertTrue(dict_contains({
             'show': show,
             'order_by': order_by,
             'func_name': func_name,
@@ -89,5 +90,5 @@ class TestProfilingContext(TestCase):
             'options_show': ProfilingView.show,
             'options_order_by': ProfilingView.order_by,
             'options_func_names': ProfilingView()._get_function_names()
-        }, context)
+        }, context))
         self.assertIn('results', context)

--- a/project/tests/test_view_requests.py
+++ b/project/tests/test_view_requests.py
@@ -6,8 +6,8 @@ from django.test import TestCase
 
 from silk.views.requests import RequestsView
 
-from .test_lib.mock_suite import MockSuite
 from .test_lib.assertion import dict_contains
+from .test_lib.mock_suite import MockSuite
 
 
 class TestRootViewDefaults(TestCase):

--- a/project/tests/test_view_requests.py
+++ b/project/tests/test_view_requests.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from silk.views.requests import RequestsView
 
 from .test_lib.mock_suite import MockSuite
+from .test_lib.assertion import dict_contains
 
 
 class TestRootViewDefaults(TestCase):
@@ -29,13 +30,13 @@ class TestContext(TestCase):
         request.session = {}
         request.GET = {}
         context = RequestsView()._create_context(request)
-        self.assertDictContainsSubset({
+        self.assertTrue(dict_contains({
             'show': RequestsView.default_show,
             'order_by': RequestsView.default_order_by,
             'options_show': RequestsView.show,
             'options_order_by': RequestsView().options_order_by,
             'options_order_dir': RequestsView().options_order_dir,
-        }, context)
+        }, context))
         self.assertQuerysetEqual(context['options_paths'], RequestsView()._get_paths())
         self.assertNotIn('path', context)
         self.assertIn('results', context)
@@ -50,14 +51,14 @@ class TestContext(TestCase):
                        'path': path,
                        'order_by': order_by}
         context = RequestsView()._create_context(request)
-        self.assertDictContainsSubset({
+        self.assertTrue(dict_contains({
             'show': show,
             'order_by': order_by,
             'path': path,
             'options_show': RequestsView.show,
             'options_order_by': RequestsView().options_order_by,
             'options_order_dir': RequestsView().options_order_dir,
-        }, context)
+        }, context))
         self.assertQuerysetEqual(context['options_paths'], RequestsView()._get_paths())
         self.assertIn('results', context)
 


### PR DESCRIPTION
Fixes #515 

`assertDictContainsSubset` has been deprecated since python 3.2 and removed in 3.11. 
 https://docs.python.org/3.11/whatsnew/3.11.html