### PR TITLE
Quality of life improvements in Requests tab

### DIFF
--- a/silk/templates/silk/base/root_base.html
+++ b/silk/templates/silk/base/root_base.html
@@ -281,6 +281,9 @@
         padding: 10px;
     }
 
+    .filter-section select {
+        margin-bottom: 10px;
+    }
     </style>
     <!-- End Custom Styles -->
 {% endblock %}

--- a/silk/templates/silk/base/root_base.html
+++ b/silk/templates/silk/base/root_base.html
@@ -277,13 +277,18 @@
     .filter-section {
         color: white;
         font-size: 12px;
-        line-height: 18px;
+        line-height: 2.3;
         padding: 10px;
     }
 
     .filter-section select {
         margin-bottom: 10px;
     }
+
+    .filter-section input {
+        padding: 4px;
+    }
+
     </style>
     <!-- End Custom Styles -->
 {% endblock %}

--- a/silk/templates/silk/base/root_base.html
+++ b/silk/templates/silk/base/root_base.html
@@ -169,6 +169,7 @@
     }
 
     .button-div {
+        display: inline-block;
         text-align: center;
         height: 50px;
 
@@ -306,7 +307,10 @@
         {% endblock %}
 
         <div class="button-div">
-            <div class="apply-div" onclick="$('#filter-form2').submit();">Apply</div>
+            <div class="apply-div" onclick="submitFilters()">Apply</div>
+        </div>
+        <div class="button-div">
+            <div class="apply-div" onclick="submitEmptyFilters()">Clear all filters</div>
         </div>
 
     </nav>
@@ -326,6 +330,13 @@
                 $('#cbp-spmenu-s2').toggleClass('cbp-spmenu-open');
                 initFilters();
             });
+        }
+        function submitFilters() {
+            $('#filter-form2').submit();
+        }
+        function submitEmptyFilters() {
+            $('#cbp-spmenu-s2 :input:not([type=hidden])').val('');
+            submitFilters();
         }
     </script>
 

--- a/silk/templates/silk/base/root_base.html
+++ b/silk/templates/silk/base/root_base.html
@@ -315,10 +315,10 @@
         {% endblock %}
 
         <div class="button-div">
-            <div class="apply-div" onclick="submitFilters()">Apply</div>
+            <div class="apply-div" onclick="submitEmptyFilters()">Clear all filters</div>
         </div>
         <div class="button-div">
-            <div class="apply-div" onclick="submitEmptyFilters()">Clear all filters</div>
+            <div class="apply-div" onclick="submitFilters()">Apply</div>
         </div>
 
     </nav>

--- a/silk/templates/silk/requests.html
+++ b/silk/templates/silk/requests.html
@@ -8,6 +8,22 @@
         .container {
             padding: 0 1em;
         }
+
+        .resizing-input input {
+            background-color: white;
+            padding-top: 2px;
+            color: black;
+            box-shadow: inset 0 0 3px black;
+        }
+
+        .resizing-input input::placeholder {
+            color: #383838;
+            opacity: 1;
+        }
+
+        .filter-section {
+            line-height: 2.3;
+        }
     </style>
 {% endblock %}
 

--- a/silk/templates/silk/requests.html
+++ b/silk/templates/silk/requests.html
@@ -2,6 +2,15 @@
 {% load silk_inclusion %}
 {% load static %}
 
+{% block style %}
+    {{ block.super }}
+    <style>
+        .container {
+            padding: 0 1em;
+        }
+    </style>
+{% endblock %}
+
 {% block menu %}
     {% root_menu request %}
 {% endblock %}
@@ -271,5 +280,12 @@
                 </a>
             {% endfor %}
         {% endif %}
+    {% else %}
+        <div class="container">
+            <h2>No matches found</h2>
+            <div class="description">
+                No requests were found with current set of filters. Please alter your filters and try again.
+            </div>
+        </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
I'm using you're package quite often and wanted to give something back to this project 😄 

This PR focuses on improving experience on _Request_ tab - one improvement per commit:
*  Add message when there are no requests to display: when there are no matches instead of displaying an empty page, let user know that there are no filter results
* Add 'Clear all filters' button - when user fills in a few filters, clearing them is rather tedious task so I thought it would be nice to have a button to clear filters.
*  Add small margin for filter selects: I think this change makes filter section looks much better.

This branch is based off 4.2.0 tag, please let me know if I need to rebase.