### PR TITLE
Use correct db in a multi db setup

### DIFF
--- a/silk/sql.py
+++ b/silk/sql.py
@@ -2,7 +2,6 @@ import logging
 import traceback
 
 from django.core.exceptions import EmptyResultSet
-from django.db import connection
 from django.utils import timezone
 
 from silk.collector import DataCollector
@@ -29,7 +28,7 @@ def _unpack_explanation(result):
             yield row
 
 
-def _explain_query(q, params):
+def _explain_query(connection, q, params):
     if connection.features.supports_explaining_query_execution:
         if SilkyConfig().SILKY_ANALYZE_QUERIES:
             # Work around some DB engines not supporting analyze option
@@ -91,7 +90,7 @@ def execute_sql(self, *args, **kwargs):
             if request:
                 query_dict['request'] = request
             if self.query.model.__module__ != 'silk.models':
-                query_dict['analysis'] = _explain_query(q, params)
+                query_dict['analysis'] = _explain_query(self.connection, q, params)
                 DataCollector().register_query(query_dict)
             else:
                 DataCollector().register_silk_query(query_dict)


### PR DESCRIPTION
SQLCompiler has a `.connection` instance which is already aware of what
database it should use. As such, when running EXPLAIN query let's use
that connection instead of connection to a default database.

Fixes #522.

I will add unit tests early next week.