### PR TITLE
Remove duplicate requirements.txt dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,11 @@
-autopep8
 contextlib2
 coverage
 factory-boy
 freezegun
-jinja2
 networkx
 pillow
 pydot
 pygments
 pytest-cov
 pytest-django
-python-dateutil
-pytz
-requests
 simplejson
-sqlparse


### PR DESCRIPTION
Packages shouldn't need to be duplicated between setup.py (dependencies for users of django-silk) and requirements.txt (dependencies for developers of django-silk).

This is a first step to pinning dependencies in `requirements.txt` as suggested in #548.