### PR TITLE
Fixing #530 - Adding support for SILKY_EXPLAIN_FLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,13 @@ To enable query analysis when supported by the dbms a config var can be set in o
 SILKY_ANALYZE_QUERIES = True
 ```
 
+To pass additional params for profiling when supported by the dbms (e.g. VERBOSE, FORMAT JSON), you can do this in the following manner.
+
+```python
+SILKY_EXPLAIN_FLAGS = {'format':'JSON', 'costs': True}
+```
+
+
 ### Masking sensitive data on request body
 
 By default, Silk is filtering values that contains the following keys (they are case insensitive)

--- a/project/tests/test_db.py
+++ b/project/tests/test_db.py
@@ -54,3 +54,16 @@ class TestAnalyzeQueries(TestCase):
 
         DataCollector().profiles.values()
         assert len(resp.context['blinds']) == 5
+
+
+class TestAnalyzeQueriesExplainParams(TestAnalyzeQueries):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        SilkyConfig().SILKY_EXPLAIN_FLAGS = {'verbose': True}
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        SilkyConfig().SILKY_EXPLAIN_FLAGS = None

--- a/silk/config.py
+++ b/silk/config.py
@@ -31,6 +31,7 @@ class SilkyConfig(metaclass=Singleton):
         'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware',
         'SILKY_JSON_ENSURE_ASCII': True,
         'SILKY_ANALYZE_QUERIES': False,
+        'SILKY_EXPLAIN_FLAGS': None,
         'SILKY_SENSITIVE_KEYS': {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}
     }
 

--- a/silk/sql.py
+++ b/silk/sql.py
@@ -38,10 +38,11 @@ def _explain_query(connection, q, params):
                 )
             except ValueError as error:
                 error_str = str(error)
-                if error_str.startswith("Unknown options:") and "analyze" in error_str:
+                if error_str.startswith("Unknown options:"):
                     Logger.warning(
-                        "Database does not support analyzing queries. "
-                        "SILKY_ANALYZE_QUERIES option will be ignored"
+                        "Database does not support analyzing queries with provided params. %s."
+                        "SILKY_ANALYZE_QUERIES option will be ignored",
+                        error_str
                     )
                     prefix = connection.ops.explain_query_prefix()
                 else:

--- a/silk/sql.py
+++ b/silk/sql.py
@@ -34,10 +34,11 @@ def _explain_query(connection, q, params):
             # Work around some DB engines not supporting analyze option
             try:
                 prefix = connection.ops.explain_query_prefix(
-                    analyze=True
+                    analyze=True, **(SilkyConfig().SILKY_EXPLAIN_FLAGS or {})
                 )
             except ValueError as error:
-                if str(error) == "Unknown options: analyze":
+                error_str = str(error)
+                if error_str.startswith("Unknown options:") and "analyze" in error_str:
                     Logger.warning(
                         "Database does not support analyzing queries. "
                         "SILKY_ANALYZE_QUERIES option will be ignored"


### PR DESCRIPTION
Adding support for additional flags that can be passed as part of the "analyze" query, for more explicit analysis.