### PR TITLE
Fix pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
   hooks:
   - id: flake8
     exclude: '^docs/'
-- repo: git://github.com/Lucas-C/pre-commit-hooks-markup
+- repo: https://github.com/Lucas-C/pre-commit-hooks-markup
   rev: v1.0.1
   hooks:
   - id: rst-linter


### PR DESCRIPTION
I was getting this error when creating #561:

```
fatal: remote error: 
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

I believe switching from `git://` to https://` should solve this problem and align this particular repository URL with all the other ones.