### PR TITLE
Fix SILKY_IGNORE_PATHS using path instead of path_info

### DIFF
--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -50,7 +50,7 @@ def _should_intercept(request):
     except NoReverseMatch:
         silky = False
 
-    ignored = request.path in config.SILKY_IGNORE_PATHS
+    ignored = request.path_info in config.SILKY_IGNORE_PATHS
     return not (silky or ignored)
 
 


### PR DESCRIPTION
Proposed solution in https://github.com/jazzband/django-silk/issues/349
@shimizukawa 
@Korben11