### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Features
 
 - SQL query inspection
 
-- Profiling of arbritary code blocks via a Python context manager and decorator
+- Profiling of arbitrary code blocks via a Python context manager and decorator
 
   - Execution Time
 

--- a/silk/profiling/dynamic.py
+++ b/silk/profiling/dynamic.py
@@ -128,7 +128,7 @@ def _new_func_from_source(source, func):
     calling_frame = frames[2][0]
 
     context = {}
-    # My initial instict was: exec src_str in func.func_globals.items(), calling_frame.f_locals
+    # My initial instinct was: exec src_str in func.func_globals.items(), calling_frame.f_locals
     # however this seems to break the function closure so caveat here is that we create a new
     # function with the locals merged into the globals.
     #


### PR DESCRIPTION
There are small typos in:
- docs/index.rst
- silk/profiling/dynamic.py

Fixes:
- Should read `instinct` rather than `instict`.
- Should read `arbitrary` rather than `arbritary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md