### PR TITLE
Use contextlib in test_profile_parser

### DIFF
--- a/project/tests/test_profile_parser.py
+++ b/project/tests/test_profile_parser.py
@@ -1,8 +1,8 @@
 import cProfile
+import contextlib
 import io
 import re
 
-import contextlib2 as contextlib
 from django.test import TestCase
 
 from silk.utils.profile_parser import parse_profile

--- a/project/tests/test_profile_parser.py
+++ b/project/tests/test_profile_parser.py
@@ -1,5 +1,5 @@
-import cProfile
 import contextlib
+import cProfile
 import io
 import re
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-contextlib2==21.6.0
 coverage==6.3.2
 factory-boy==3.2.1
 freezegun==1.1.0


### PR DESCRIPTION
Since the project no longer declares a requirement of contextlib2, and
the lowest version of Python supported is 3.7, we should remove the use
of contextlib2. Switch the import to contextlib.