### PR TITLE
Remove unneeded pytz package

### DIFF
--- a/project/tests/test_filters.py
+++ b/project/tests/test_filters.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from itertools import groupby
 from math import floor
 
-import pytz
 from django.test import TestCase
 from django.utils import timezone
 
@@ -148,7 +147,7 @@ class TestRequestAfterDateFilter(TestCase):
         date_filter = AfterDateFilter
         f = date_filter(dt_str)
         new_dt = datetime.strptime(dt_str, fmt)
-        new_dt = timezone.make_aware(new_dt, pytz.UTC)
+        new_dt = timezone.make_aware(new_dt, timezone.utc)
         self.assertFilter(new_dt, f)
 
 
@@ -177,7 +176,7 @@ class TestRequestBeforeDateFilter(TestCase):
         date_filter = BeforeDateFilter
         f = date_filter(dt_str)
         new_dt = datetime.strptime(dt_str, fmt)
-        new_dt = timezone.make_aware(new_dt, pytz.UTC)
+        new_dt = timezone.make_aware(new_dt, timezone.utc)
         self.assertFilter(new_dt, f)
 
 

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -1,9 +1,9 @@
 import datetime
 import uuid
 
-import pytz
 from django.core.management import call_command
 from django.test import TestCase, override_settings
+from django.utils import timezone
 from freezegun import freeze_time
 
 from silk import models
@@ -45,7 +45,7 @@ class RequestTest(TestCase):
     def test_start_time_field_default(self):
 
         obj = RequestMinFactory.create()
-        self.assertEqual(obj.start_time, datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=pytz.UTC))
+        self.assertEqual(obj.start_time, datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_total_meta_time_if_have_no_meta_and_queries_time(self):
 
@@ -185,7 +185,7 @@ class RequestTest(TestCase):
     @freeze_time('2016-01-01 12:00:00')
     def test_save_if_have_end_time(self):
 
-        date = datetime.datetime(2016, 1, 1, 12, 0, 3, tzinfo=pytz.UTC)
+        date = datetime.datetime(2016, 1, 1, 12, 0, 3, tzinfo=timezone.utc)
         obj = models.Request(path='/some/path/', method='get', end_time=date)
         obj.save()
         self.assertEqual(obj.end_time, date)
@@ -262,14 +262,14 @@ class SQLQueryTest(TestCase):
     def setUp(self):
 
         self.obj = SQLQueryFactory.create()
-        self.end_time = datetime.datetime(2016, 1, 1, 12, 0, 5, tzinfo=pytz.UTC)
-        self.start_time = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=pytz.UTC)
+        self.end_time = datetime.datetime(2016, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
+        self.start_time = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     @freeze_time('2016-01-01 12:00:00')
     def test_start_time_field_default(self):
 
         obj = SQLQueryFactory.create()
-        self.assertEqual(obj.start_time, datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=pytz.UTC))
+        self.assertEqual(obj.start_time, datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_is_m2o_related_to_request(self):
 
@@ -432,7 +432,7 @@ class SQLQueryTest(TestCase):
     @freeze_time('2016-01-01 12:00:00')
     def test_save_if_has_end_time(self):
 
-        # datetime.datetime(2016, 1, 1, 12, 0, 5, tzinfo=pytz.UTC)
+        # datetime.datetime(2016, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
         obj = SQLQueryFactory.create(end_time=self.end_time)
 
         self.assertEqual(obj.time_taken, 5000.0)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'sqlparse',
         'Jinja2',
         'autopep8',
-        'pytz',
         'gprof2dot>=2017.09.19',
     ],
     python_requires='>=3.7',


### PR DESCRIPTION
Following up on #581, remove the `pytz` package which was only being used in tests to load the UTC offset which by definition is always 0.  `django.utils.timezone.utc` (as well as `datetime.timezone.utc`) both suffice and are already available to be imported in django-silk.

Fixes #581