### PR TITLE
Add Python 3.11 to CI, tox, and trove classifiers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         django-version: ['3.2', '4.0', '4.1', 'main']
 
     services:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Silk is a live profiling and inspection tool for the Django framework. Silk inte
 Silk has been tested with:
 
 * Django: 3.2, 4.0, 4.1
-* Python: 3.7, 3.8, 3.9, 3.10
+* Python: 3.7, 3.8, 3.9, 3.10, 3.11
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 DJANGO =
@@ -14,8 +15,8 @@ DJANGO =
 
 [tox]
 envlist =
-    py{37,38,39,310}-dj32-{sqlite3,mysql,postgresql}
-    py{38,39,310}-dj{40,41,main}-{sqlite3,mysql,postgresql}
+    py{37,38,39,310,311}-dj32-{sqlite3,mysql,postgresql}
+    py{38,39,310,311}-dj{40,41,main}-{sqlite3,mysql,postgresql}
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ changedir = {toxinidir}/project
 deps =
     -rrequirements.txt
     mysql: mysqlclient
-    postgresql: psycopg2-binary<2.9
+    postgresql: psycopg2-binary
     dj32: django>=3.2,<3.3
     dj40: django>=4.0,<4.1
     dj41: django>=4.1,<4.2

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,9 @@ DJANGO =
 
 [tox]
 envlist =
-    py{37,38,39,310,311}-dj32-{sqlite3,mysql,postgresql}
-    py{38,39,310,311}-dj{40,41,main}-{sqlite3,mysql,postgresql}
+    py{37,38,39,310}-dj32-{sqlite3,mysql,postgresql}
+    py{38,39,310}-dj{40,41,main}-{sqlite3,mysql,postgresql}
+    py311-dj{41,main}-{sqlite3,mysql,postgresql}
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Adds Python 3.11 to GHA test workflow job matrix, tox, and trove classifers. Updates the README to add 3.11 to list of Python versions `django-silk` has been tested against.

Also removes the `<2.9` version restriction from the `psycopg2-binary` dependency in the Postgres tox env, as that was seemingly added as a temporary fix for Django 2.2 (#486), which this package no longer supports.