### PR TITLE
Switch Django dev in CI to Postgres 12 and MariaDB 10.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,14 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0', '4.1', 'main']
+        postgres-version: ['11']
+      include:
+        django-version: ['main']
+        postgres-version: ['12']
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:${{ matrix.postgres-version }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,14 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0', '4.1', 'main']
-        postgres-version: ['11']
-        include:
-          - django-version: 'main'
+        postgres-version: ['11', '12']
+        exclude:
+          # only test Django dev with PostgreSQL 12
+          - django-version: '3.2'
+            postgres-version: '12'
+          - django-version: '4.0'
+            postgres-version: '12'
+          - django-version: '4.1'
             postgres-version: '12'
 
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
         django-version: ['3.2', '4.0', '4.1', 'main']
         postgres-version: ['11']
         include:
-          django-version: ['main']
-          postgres-version: ['12']
+          django-version: 'main'
+          postgres-version: '12'
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0', '4.1', 'main']
         postgres-version: ['11']
-      include:
-        django-version: ['main']
-        postgres-version: ['12']
+        include:
+          django-version: ['main']
+          postgres-version: ['12']
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
             postgres-version: '12'
           - django-version: '4.1'
             postgres-version: '12'
+          - django-version: 'main'
+            postgres-version: '11'
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,22 @@ jobs:
           # only test Django dev with PostgreSQL 12 and MariaDB 10.4
           - django-version: '3.2'
             postgres-version: '12'
+          - django-version: '3.2'
             mariadb-version: '10.4'
+          
           - django-version: '4.0'
             postgres-version: '12'
+          - django-version: '4.0'
             mariadb-version: '10.4'
+
           - django-version: '4.1'
             postgres-version: '12'
+          - django-version: '4.1'
             mariadb-version: '10.4'
+
           - django-version: 'main'
             postgres-version: '11'
+          - django-version: 'main'
             mariadb-version: '10.3'
 
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,21 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0', '4.1', 'main']
         postgres-version: ['11', '12']
+        mariadb-version: ['10.3', '10.4']
         exclude:
-          # only test Django dev with PostgreSQL 12
+          # only test Django dev with PostgreSQL 12 and MariaDB 10.4
           - django-version: '3.2'
             postgres-version: '12'
+            mariadb-version: '10.4'
           - django-version: '4.0'
             postgres-version: '12'
+            mariadb-version: '10.4'
           - django-version: '4.1'
             postgres-version: '12'
+            mariadb-version: '10.4'
           - django-version: 'main'
             postgres-version: '11'
+            mariadb-version: '10.3'
 
     services:
       postgres:
@@ -39,7 +44,7 @@ jobs:
           --health-retries 5
 
       mariadb:
-        image: mariadb:10.3
+        image: mariadb:${{ matrix.mariadb-version }}
         env:
           MYSQL_ROOT_PASSWORD: mysql
           MYSQL_DATABASE: mysql

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
         django-version: ['3.2', '4.0', '4.1', 'main']
         postgres-version: ['11']
         include:
-          django-version: 'main'
-          postgres-version: '12'
+          - django-version: 'main'
+            postgres-version: '12'
 
     services:
       postgres:


### PR DESCRIPTION
Adds `postgres-version` and `mariadb-version` to CI job matrix and restricts `django-version` to running the lowest supported DB version for that release of Django.

Django development supports Postgres >12 and MariaDB >10.4, so in CI those two tox envs were failing across all Python versions:

```shell
___________________________________ summary ____________________________________
  py310-djmain-sqlite3: commands succeeded
  py310-djmain-mysql: ignored failed command
  py310-djmain-postgresql: ignored failed command
  congratulations :)
```

[https://docs.djangoproject.com/en/dev/ref/databases/#postgresql-notes]()
[https://docs.djangoproject.com/en/dev/ref/databases/#mariadb-notes]()