### PR TITLE
#46 Retain ordering, view style and limit

### DIFF
--- a/project/tests/test_view_requests.py
+++ b/project/tests/test_view_requests.py
@@ -63,6 +63,20 @@ class TestContext(TestCase):
         self.assertQuerysetEqual(context['options_paths'], RequestsView()._get_paths())
         self.assertIn('results', context)
 
+    def test_post(self):
+        response = self.client.post(silky_reverse('requests'), {
+            'filter-overalltime-value': 100,
+            'filter-overalltime-typ': 'TimeSpentOnQueriesFilter',
+        })
+        context = response.context
+        self.assertTrue(dict_contains({
+            'filters': {
+                'overalltime': {'typ': 'TimeSpentOnQueriesFilter', 'value': 100, 'str': 'DB Time >= 100'}
+            },
+        }, context))
+        self.assertQuerysetEqual(context['options_paths'], RequestsView()._get_paths())
+        self.assertIn('results', context)
+
 
 class TestGetObjects(TestCase):
     def assertSorted(self, objects, sort_field):

--- a/project/tests/test_view_requests.py
+++ b/project/tests/test_view_requests.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 from django.test import TestCase
 
+from silk.middleware import silky_reverse
 from silk.views.requests import RequestsView
 
 from .test_lib.assertion import dict_contains
@@ -42,15 +43,15 @@ class TestContext(TestCase):
         self.assertIn('results', context)
 
     def test_get(self):
-        request = Mock(spec_set=['GET', 'session'])
-        request.session = {}
         show = 10
         path = '/path/to/somewhere/'
         order_by = 'path'
-        request.GET = {'show': show,
-                       'path': path,
-                       'order_by': order_by}
-        context = RequestsView()._create_context(request)
+        response = self.client.get(silky_reverse('requests'), {
+            'show': show,
+            'path': path,
+            'order_by': order_by,
+        })
+        context = response.context
         self.assertTrue(dict_contains({
             'show': show,
             'order_by': order_by,

--- a/silk/templates/silk/base/root_base.html
+++ b/silk/templates/silk/base/root_base.html
@@ -307,12 +307,11 @@
     <nav class="cbp-spmenu cbp-spmenu-vertical cbp-spmenu-right" id="cbp-spmenu-s2">
         <h3>Filters</h3>
 
-        <form id="filter-form2" action="." method="post">{% csrf_token %}</form>
-
-
-        {% block filters %}
-
-        {% endblock %}
+        <form id="filter-form2" action="" method="post">
+            {% csrf_token %}
+            {% block filters %}{% endblock %}
+            <input type="submit" style="display: none">
+        </form>
 
         <div class="button-div">
             <div class="apply-div" onclick="submitEmptyFilters()">Clear all filters</div>


### PR DESCRIPTION
Two enhancements in this PR:
 - the `'show', 'order_by', 'order_dir', 'view_style'` params are retained so when you click on the "Requests" menu item, you keep these (they won't be reset when "Clear all filters" is clicked as they are not filters)
 - a invisible submit button was added to filter form so that when you set a value and press enter, the form is submitted

I will open a cleanup issue, as I find the filters form heavily relying on JavaScript, and it should not be IMHO.