### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ freezegun==1.1.0
 networkx==2.6
 pillow==9.3.0
 pydot==1.4.2
-pygments==2.11.2
+pygments==2.13.0
 pytest-cov==3.0.0
 pytest-django==4.5.2
 simplejson==3.17.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ networkx==2.6
 pillow==9.3.0
 pydot==1.4.2
 pygments==2.13.0
-pytest-cov==3.0.0
+pytest-cov==4.0.0
 pytest-django==4.5.2
 simplejson==3.17.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-coverage==6.3.2
+coverage==6.5.0
 factory-boy==3.2.1
 freezegun==1.1.0
 networkx==2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage==6.5.0
 factory-boy==3.2.1
-freezegun==1.1.0
+freezegun==1.2.2
 networkx==2.6
 pillow==9.3.0
 pydot==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ coverage==6.3.2
 factory-boy==3.2.1
 freezegun==1.1.0
 networkx==2.6
-pillow==9.0.1
+pillow==9.3.0
 pydot==1.4.2
 pygments==2.11.2
 pytest-cov==3.0.0


### PR DESCRIPTION
Updates all python dependencies to the latest releases, with the exception of `networkx` because `networkx` 2.8.8 drops support for python 3.7.