### PR TITLE
Allow to generate more informative profile file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ SILKY_PYTHON_PROFILER_RESULT_PATH = '/path/to/profiles/'
 
 A download button will become available with a binary `.prof` file for every request. This file can be used for further analysis using [snakeviz](https://github.com/jiffyclub/snakeviz) or other cProfile tools
 
+To retrieve which endpoint generates a specific profile file it is possible to add a stub of the request path in the file name with the following:
+
+```python
+SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME = True
+```
 
 Silk can also be used to profile specific blocks of code/functions. It provides a decorator and a context
 manager for this purpose.

--- a/project/tests/test_collector.py
+++ b/project/tests/test_collector.py
@@ -47,22 +47,38 @@ class TestCollector(TestCase):
                 self.assertTrue(content)
                 self.assertGreater(len(content), 0)
 
-    def test_profile_file_name(self):
+    def test_profile_file_name_with_disabled_extended_file_name(self):
+        SilkyConfig().SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME = False
+        request_path = 'normal/uri/'
+        resulting_prefix = self._get_prof_file_name(request_path)
+        self.assertEqual(resulting_prefix, '')
+
+    def test_profile_file_name_with_enabled_extended_file_name(self):
+
+        SilkyConfig().SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME = True
+        request_path = 'normal/uri/'
+        resulting_prefix = self._get_prof_file_name(request_path)
+        self.assertEqual(resulting_prefix, 'normal_uri_')
+
+    def test_profile_file_name_with_path_traversal_and_special_char(self):
+        SilkyConfig().SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME = True
+        request_path = 'spÉciàl/.././大/uri/@É/'
+        resulting_prefix = self._get_prof_file_name(request_path)
+        self.assertEqual(resulting_prefix, 'special_uri_e_')
+
+    def test_profile_file_name_with_long_path(self):
+        SilkyConfig().SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME = True
+        request_path = 'long/path/' + 'a' * 100
+        resulting_prefix = self._get_prof_file_name(request_path)
+        # the path is limited to 50 char plus the last `_`
+        self.assertEqual(len(resulting_prefix), 51)
+
+    @classmethod
+    def _get_prof_file_name(cls, request_path: str) -> str:
         request = RequestMinFactory()
+        request.path = request_path
         DataCollector().configure(request)
-        expected_file_name_prefix = request.path.replace('/', '_').lstrip('_')
-        print(expected_file_name_prefix)
-
-        with self.subTest("With disabled extended file name"):
-            SilkyConfig().SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME = False
-            DataCollector().finalise()
-            file = DataCollector().request.prof_file
-            result_file_name = file.name.rsplit('/')[-1]
-            self.assertFalse(result_file_name.startswith(f"{expected_file_name_prefix}_"))
-
-        with self.subTest("With enabled extended file name"):
-            SilkyConfig().SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME = True
-            DataCollector().finalise()
-            file = DataCollector().request.prof_file
-            result_file_name = file.name.rsplit('/')[-1]
-            self.assertTrue(result_file_name.startswith(f"{expected_file_name_prefix}_"))
+        DataCollector().finalise()
+        file_path = DataCollector().request.prof_file.name
+        filename = file_path.rsplit('/')[-1]
+        return filename.replace(f"{request.id}.prof", "")

--- a/silk/collector.py
+++ b/silk/collector.py
@@ -143,7 +143,8 @@ class DataCollector(metaclass=Singleton):
             self.request.pyprofile = profile_text
 
             if SilkyConfig().SILKY_PYTHON_PROFILER_BINARY:
-                file_name = self.request.prof_file.storage.get_available_name(f"{str(self.request.id)}.prof")
+                proposed_file_name = self._get_proposed_file_name()
+                file_name = self.request.prof_file.storage.get_available_name(proposed_file_name)
                 with self.request.prof_file.storage.open(file_name, 'w+b') as f:
                     marshal.dump(ps.stats, f)
                 self.request.prof_file = f.name
@@ -189,3 +190,11 @@ class DataCollector(metaclass=Singleton):
 
     def register_silk_query(self, *args):
         self.register_objects(TYP_SILK_QUERIES, *args)
+
+    def _get_proposed_file_name(self):
+        """Retrieve the profile file name to be proposed to the storage"""
+
+        if SilkyConfig().SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME:
+            request_path = self.request.path.replace('/', '_').lstrip('_')
+            return f"{request_path}_{str(self.request.id)}.prof"
+        return f"{str(self.request.id)}.prof"

--- a/silk/config.py
+++ b/silk/config.py
@@ -28,6 +28,7 @@ class SilkyConfig(metaclass=Singleton):
         'SILKY_PYTHON_PROFILER': False,
         'SILKY_PYTHON_PROFILER_FUNC': None,
         'SILKY_STORAGE_CLASS': 'silk.storage.ProfilerResultStorage',
+        'SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME': False,
         'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware',
         'SILKY_JSON_ENSURE_ASCII': True,
         'SILKY_ANALYZE_QUERIES': False,


### PR DESCRIPTION
The aim of this pull request is to generate a more informative profile file name. This would allow us to identify the endpoint that generates a profile file without the need to open it.

To avoid breaking any existent use case I set this behavior behind the setting `SILKY_PYTHON_PROFILER_EXTENDED_FILE_NAME` that by default is disabled.

If you think we can change the generated filename without worry we can simply apply this change always without the need to introduce the new settings.
