### PR TITLE
Prune test matrix of unsupported python/django combinations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,20 @@ jobs:
         postgres-version: ['11', '12']
         mariadb-version: ['10.3', '10.4']
         exclude:
+          # Django >=4.0 drops support for python 3.7 (https://docs.djangoproject.com/en/4.1/faq/install/)
+          - python-version: '3.7'
+            django-version: '4.0'
+          - python-version: '3.7'
+            django-version: '4.1'
+          - python-version: '3.7'
+            django-version: 'main'
+
+          # Django <=4.0 doesn't support python 3.11 (https://docs.djangoproject.com/en/4.1/faq/install/)
+          - python-version: '3.11'
+            django-version: '3.2'
+          - python-version: '3.11'
+            django-version: '4.0'
+
           # only test Django dev with PostgreSQL 12 and MariaDB 10.4
           - django-version: '3.2'
             postgres-version: '12'


### PR DESCRIPTION
According to https://docs.djangoproject.com/en/4.1/faq/install/, django versions >= 4.0 do not support python 3.7 anymore and django versions <= 4.0 do not support python 3.11.  This PR excludes those 5 combinations of python and django versions from being tested.  Also, the tests for those 5 combinations of django and python are failing.  