### PR TITLE
Run django-upgrade manually

### DIFF
--- a/project/example_app/admin.py
+++ b/project/example_app/admin.py
@@ -4,10 +4,14 @@ from django.urls import reverse
 from .models import Blind
 
 
+@admin.register(Blind)
 class BlindAdmin(admin.ModelAdmin):
     list_display = ('desc', 'thumbnail', 'name', 'child_safe')
     list_editable = ('name', 'child_safe')
 
+    @admin.display(
+        description='Photo'
+    )
     def thumbnail(self, obj):
         try:
             img_tag = '<img src="%s" width="200px"/>' % obj.photo.url
@@ -16,20 +20,14 @@ class BlindAdmin(admin.ModelAdmin):
         url = self._blind_url(obj)
         return f'<a href="{url}">{img_tag}</a>'
 
-    thumbnail.short_description = 'Photo'
-    thumbnail.allow_tags = True
-
     def _blind_url(self, obj):
         url = reverse('admin:example_app_blind_change', args=(obj.id, ))
         return url
 
+    @admin.display(
+        description='Blind'
+    )
     def desc(self, obj):
         desc = str(obj)
         url = self._blind_url(obj)
         return f'<a href="{url}">{desc}</a>'
-
-    desc.short_description = 'Blind'
-    desc.allow_tags = True
-
-
-admin.site.register(Blind, BlindAdmin)

--- a/project/tests/urlconf_without_silk.py
+++ b/project/tests/urlconf_without_silk.py
@@ -1,8 +1,8 @@
-from django.urls import include, re_path
+from django.urls import include, path
 
 urlpatterns = [
-    re_path(
-        r'^example_app/',
+    path(
+        'example_app/',
         include('example_app.urls', namespace='example_app')
     ),
 ]


### PR DESCRIPTION
Debugging the failures in #620 , I ran django-upgrade manually to find what it was doing to files to cause the tests to fail.  This PR contains the changes from running django-upgrade manually (and matches #620) except for the below change from django-upgrade which breaks tests and therefore is not included in this PR:

```diff
diff --git a/silk/model_factory.py b/silk/model_factory.py
index ba21fed..9a091c0 100644
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -74,7 +74,7 @@ class RequestModelFactory:
         self.request = request

     def content_type(self):
-        content_type = self.request.META.get('CONTENT_TYPE', '')
+        content_type = self.request.headers.get('content-type', '')
         return _parse_content_type(content_type)

     def encoded_headers(self):
```

After this PR is landed, pre-commit CI can regenerate #620 and the auto-linter can continue to work.  https://github.com/albertyw/django-silk/blob/master/.pre-commit-config.yaml#L54-L58 may need to be commented out though to prevent the above change from reappearing.  