### PR TITLE
Switch from request META to request headers

### DIFF
--- a/project/tests/test_compat.py
+++ b/project/tests/test_compat.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from silk.model_factory import ResponseModelFactory
 
 DJANGO_META_CONTENT_TYPE = 'CONTENT_TYPE'
-HTTP_CONTENT_TYPE = 'Content-Type'
+HTTP_CONTENT_TYPE = 'content-type'
 
 
 class TestByteStringCompatForResponse(TestCase):

--- a/project/tests/test_config_long_urls.py
+++ b/project/tests/test_config_long_urls.py
@@ -10,7 +10,7 @@ class TestLongRequestUrl(TestCase):
     def test_no_long_url(self):
         url = '1234567890' * 19  # 190-character URL
         mock_request = Mock()
-        mock_request.META = {'CONTENT_TYPE': 'text/plain'}
+        mock_request.headers = {'content-type': 'text/plain'}
         mock_request.GET = {}
         mock_request.path = url
         mock_request.method = 'get'
@@ -20,7 +20,7 @@ class TestLongRequestUrl(TestCase):
     def test_long_url(self):
         url = '1234567890' * 200  # 2000-character URL
         mock_request = Mock()
-        mock_request.META = {'CONTENT_TYPE': 'text/plain'}
+        mock_request.headers = {'content-type': 'text/plain'}
         mock_request.GET = {}
         mock_request.method = 'get'
         mock_request.path = url

--- a/project/tests/test_config_max_body_size.py
+++ b/project/tests/test_config_max_body_size.py
@@ -14,7 +14,7 @@ class TestMaxBodySizeRequest(TestCase):
     def test_no_max_request(self):
         SilkyConfig().SILKY_MAX_REQUEST_BODY_SIZE = -1
         mock_request = Mock()
-        mock_request.META = {'CONTENT_TYPE': 'text/plain'}
+        mock_request.headers = {'content-type': 'text/plain'}
         mock_request.GET = {}
         mock_request.path = reverse('silk:requests')
         mock_request.method = 'get'
@@ -25,7 +25,7 @@ class TestMaxBodySizeRequest(TestCase):
     def test_max_request(self):
         SilkyConfig().SILKY_MAX_REQUEST_BODY_SIZE = 10  # 10kb
         mock_request = Mock()
-        mock_request.META = {'CONTENT_TYPE': 'text/plain'}
+        mock_request.headers = {'content-type': 'text/plain'}
         mock_request.GET = {}
         mock_request.method = 'get'
         mock_request.body = b'a' * 1024 * 100  # 100kb
@@ -42,9 +42,7 @@ class TestMaxBodySizeResponse(TestCase):
     def test_no_max_response(self):
         SilkyConfig().SILKY_MAX_RESPONSE_BODY_SIZE = -1
         mock_response = Mock()
-        headers = {'CONTENT_TYPE': 'text/plain'}
-        mock_response.get = headers.get
-        mock_response.headers = headers
+        mock_response.headers = {'content-type': 'text/plain'}
         mock_response.content = b'a' * 1000  # 1000 bytes?
         mock_response.status_code = 200
         response_model = ResponseModelFactory(mock_response).construct_response_model()
@@ -53,9 +51,7 @@ class TestMaxBodySizeResponse(TestCase):
     def test_max_response(self):
         SilkyConfig().SILKY_MAX_RESPONSE_BODY_SIZE = 10  # 10kb
         mock_response = Mock()
-        headers = {'CONTENT_TYPE': 'text/plain'}
-        mock_response.get = headers.get
-        mock_response.headers = headers
+        mock_response.headers = {'content-type': 'text/plain'}
         mock_response.content = b'a' * 1024 * 100  # 100kb
         mock_response.status_code = 200
         response_model = ResponseModelFactory(mock_response).construct_response_model()

--- a/project/tests/test_config_max_body_size.py
+++ b/project/tests/test_config_max_body_size.py
@@ -45,6 +45,7 @@ class TestMaxBodySizeResponse(TestCase):
         mock_response.headers = {'content-type': 'text/plain'}
         mock_response.content = b'a' * 1000  # 1000 bytes?
         mock_response.status_code = 200
+        mock_response.get = mock_response.headers.get
         response_model = ResponseModelFactory(mock_response).construct_response_model()
         self.assertTrue(response_model.raw_body)
 
@@ -54,5 +55,6 @@ class TestMaxBodySizeResponse(TestCase):
         mock_response.headers = {'content-type': 'text/plain'}
         mock_response.content = b'a' * 1024 * 100  # 100kb
         mock_response.status_code = 200
+        mock_response.get = mock_response.headers.get
         response_model = ResponseModelFactory(mock_response).construct_response_model()
         self.assertFalse(response_model.raw_body)

--- a/project/tests/test_encoding.py
+++ b/project/tests/test_encoding.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 from silk.model_factory import RequestModelFactory, ResponseModelFactory
 
-HTTP_CONTENT_TYPE = 'Content-Type'
+HTTP_CONTENT_TYPE = 'content-type'
 
 
 class TestEncodingForRequests(TestCase):

--- a/project/tests/test_encoding.py
+++ b/project/tests/test_encoding.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 
 from silk.model_factory import RequestModelFactory, ResponseModelFactory
 
-DJANGO_META_CONTENT_TYPE = 'CONTENT_TYPE'
 HTTP_CONTENT_TYPE = 'Content-Type'
 
 
@@ -16,9 +15,9 @@ class TestEncodingForRequests(TestCase):
 
     def test_utf_plain(self):
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'text/plain; charset=UTF-8'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'text/plain; charset=UTF-8'}
         mock_request.body = '语'
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
         self.assertFalse(body)
@@ -26,9 +25,9 @@ class TestEncodingForRequests(TestCase):
 
     def test_plain(self):
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'text/plain'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'text/plain'}
         mock_request.body = 'sdfsdf'
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
         self.assertFalse(body)
@@ -36,10 +35,10 @@ class TestEncodingForRequests(TestCase):
 
     def test_utf_json_not_encoded(self):
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'application/json; charset=UTF-8'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'application/json; charset=UTF-8'}
         d = {'x': '语'}
         mock_request.body = json.dumps(d)
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
         self.assertDictEqual(json.loads(body), d)
@@ -47,10 +46,10 @@ class TestEncodingForRequests(TestCase):
 
     def test_utf_json_encoded(self):
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'application/json; charset=UTF-8'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'application/json; charset=UTF-8'}
         d = {'x': '语'}
         mock_request.body = json.dumps(d).encode('UTF-8')
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
         self.assertDictEqual(json.loads(body), d)
@@ -59,10 +58,10 @@ class TestEncodingForRequests(TestCase):
     def test_utf_json_encoded_no_charset(self):
         """default to UTF-8"""
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'application/json'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'application/json'}
         d = {'x': '语'}
         mock_request.body = json.dumps(d).encode('UTF-8')
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
         self.assertDictEqual(json.loads(body), d)
@@ -70,10 +69,10 @@ class TestEncodingForRequests(TestCase):
 
     def test_invalid_encoding_json(self):
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'application/json; charset=asdas-8'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'application/json; charset=asdas-8'}
         d = {'x': '语'}
         mock_request.body = json.dumps(d).encode('UTF-8')
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
         self.assertDictEqual(json.loads(body), d)

--- a/project/tests/test_multipart_forms.py
+++ b/project/tests/test_multipart_forms.py
@@ -10,7 +10,7 @@ class TestMultipartForms(TestCase):
 
     def test_no_max_request(self):
         mock_request = Mock()
-        mock_request.META = {'CONTENT_TYPE': multipart_form}
+        mock_request.headers = {'content-type': multipart_form}
         mock_request.GET = {}
         mock_request.path = reverse('silk:requests')
         mock_request.method = 'post'

--- a/project/tests/test_sensitive_data_in_request.py
+++ b/project/tests/test_sensitive_data_in_request.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from silk.config import SilkyConfig
 from silk.model_factory import RequestModelFactory
 
-HTTP_CONTENT_TYPE = 'Content-Type'
+HTTP_CONTENT_TYPE = 'content-type'
 CLEANSED = RequestModelFactory.CLEANSED_SUBSTITUTE
 DEFAULT_SENSITIVE_KEYS = {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}
 

--- a/project/tests/test_sensitive_data_in_request.py
+++ b/project/tests/test_sensitive_data_in_request.py
@@ -6,7 +6,6 @@ from django.test import TestCase
 from silk.config import SilkyConfig
 from silk.model_factory import RequestModelFactory
 
-DJANGO_META_CONTENT_TYPE = 'CONTENT_TYPE'
 HTTP_CONTENT_TYPE = 'Content-Type'
 CLEANSED = RequestModelFactory.CLEANSED_SUBSTITUTE
 DEFAULT_SENSITIVE_KEYS = {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}
@@ -130,9 +129,9 @@ class TestEncodingForRequests(TestCase):
 
     def test_password_in_body(self):
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'text/plain'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'text/plain'}
         mock_request.body = 'username=test_username&unmasked=testunmasked&password=testpassword'
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
 
@@ -144,11 +143,11 @@ class TestEncodingForRequests(TestCase):
 
     def test_password_in_json(self):
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'application/json; charset=UTF-8'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'application/json; charset=UTF-8'}
         d = {'x': 'testunmasked', 'username': 'test_username', 'password': 'testpassword',
              'prefixed-secret': 'testsecret'}
         mock_request.body = json.dumps(d)
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
         self.assertIn('testunmasked', raw_body)
@@ -167,13 +166,13 @@ class TestEncodingForRequests(TestCase):
 
     def test_password_in_batched_json(self):
         mock_request = Mock()
-        mock_request.META = {DJANGO_META_CONTENT_TYPE: 'application/json; charset=UTF-8'}
+        mock_request.headers = {HTTP_CONTENT_TYPE: 'application/json; charset=UTF-8'}
         d = [
             {'x': 'testunmasked', 'username': 'test_username', 'password': 'testpassword'},
             {'x': 'testunmasked', 'username': 'test_username', 'password': 'testpassword'}
         ]
         mock_request.body = json.dumps(d)
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         body, raw_body = factory.body()
         self.assertIn('testunmasked', raw_body)
@@ -192,9 +191,9 @@ class TestEncodingForRequests(TestCase):
 
     def test_authorization_header(self):
         mock_request = Mock()
-        mock_request.META = {'HTTP_AUTHORIZATION': 'secret'}
+        mock_request.headers = {'HTTP_AUTHORIZATION': 'secret'}
         mock_request.body = ''
-        mock_request.get = mock_request.META.get
+        mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         headers = factory.encoded_headers()
         json_headers = json.loads(headers)

--- a/project/tests/test_sensitive_data_in_request.py
+++ b/project/tests/test_sensitive_data_in_request.py
@@ -191,12 +191,12 @@ class TestEncodingForRequests(TestCase):
 
     def test_authorization_header(self):
         mock_request = Mock()
-        mock_request.headers = {'HTTP_AUTHORIZATION': 'secret'}
+        mock_request.headers = {'authorization': 'secret'}
         mock_request.body = ''
         mock_request.get = mock_request.headers.get
         factory = RequestModelFactory(mock_request)
         headers = factory.encoded_headers()
         json_headers = json.loads(headers)
 
-        self.assertIn('AUTHORIZATION', json_headers)
-        self.assertEqual(json_headers['AUTHORIZATION'], RequestModelFactory.CLEANSED_SUBSTITUTE)
+        self.assertIn('authorization', json_headers)
+        self.assertEqual(json_headers['authorization'], RequestModelFactory.CLEANSED_SUBSTITUTE)

--- a/silk/code_generation/curl.py
+++ b/silk/code_generation/curl.py
@@ -5,7 +5,7 @@ from django.template import Context, Template
 
 curl_template = """
 curl {% if method %}-X {{ method }}{% endif %}
-{% if content_type %}-H 'Content-Type: {{ content_type }}'{% endif %}
+{% if content_type %}-H 'content-type: {{ content_type }}'{% endif %}
 {% if modifier %}{{ modifier }} {% endif %}{% if body %}'{{ body }}'{% endif %}
 {{ url }}{% if query_params %}{{ query_params }}{% endif %}
 {% if extra %}{{ extra }}{% endif %}

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -45,7 +45,7 @@ class DefaultEncoder(json.JSONEncoder):
 
 
 def _parse_content_type(content_type):
-    """best efforts on pulling out the content type and encoding from Content-Type header"""
+    """best efforts on pulling out the content type and encoding from content-type header"""
     char_set = None
     if content_type.strip():
         splt = content_type.split(';')
@@ -267,7 +267,7 @@ class ResponseModelFactory:
 
     def body(self):
         body = ''
-        content_type, char_set = _parse_content_type(self.response.get('Content-Type', ''))
+        content_type, char_set = _parse_content_type(self.response.get('content-type', ''))
         content = getattr(self.response, 'content', '')
         if content:
             max_body_size = SilkyConfig().SILKY_MAX_RESPONSE_BODY_SIZE


### PR DESCRIPTION
As recommended by https://github.com/adamchainz/django-upgrade#httprequestheaders, switch from `request.META` to `request.headers`.  This slightly simplifies several test cases by not having to convert between META and headers (see https://docs.djangoproject.com/en/dev/ref/request-response/#httprequest-objects for more information).  However, headers are case insensitive which introduces some case-changes.  

All of the changes in this PR are limited to tests, except for a very minor change when generating curls.

This is a followup to https://github.com/jazzband/django-silk/pull/640#issuecomment-1375269162