### PR TITLE
Remove unneeded content_type strip

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -46,10 +46,6 @@ class DefaultEncoder(json.JSONEncoder):
 
 def _parse_content_type(content_type):
     """best efforts on pulling out the content type and encoding from Content-Type header"""
-    try:
-        content_type = content_type.strip()
-    except AttributeError:
-        pass
     char_set = None
     if content_type.strip():
         splt = content_type.split(';')


### PR DESCRIPTION
Based on the comment https://github.com/jazzband/django-silk/pull/641#pullrequestreview-1245196140, there's not a good reason to have these lines that attempt to strip `content_type`.  

If `strip()` is a method on a string, `strip()` will return a string making the `strip()` a few lines below superfluous (`s.strip().strip() == s.strip()`).  If `strip()` does trigger the try/catch, the try/catch will be ineffective anyways because the later `strip()` will also trigger an `AttributeError`.  There is a possibility that a different type implements `strip()` in a way that multiple strips have different behavior, but it doesn't seem possible given how the `_parse_content_type` function is called.