### PR TITLE
Remove support for looking up headers on django <3.2

### DIFF
--- a/project/tests/test_compat.py
+++ b/project/tests/test_compat.py
@@ -23,18 +23,3 @@ class TestByteStringCompatForResponse(TestCase):
         factory = ResponseModelFactory(mock)
         body, content = factory.body()
         self.assertDictEqual(json.loads(body), d)
-
-    # Testing invalid json throws an exception in the tests
-    # def test_python3_invalid_content_compat(self):
-    #     """
-    #     Test ResponseModelFactory returns empty string for invalid json
-    #     """
-    #     if sys.version_info >= (3, 0, 0):
-    #         mock = Mock()
-    #         mock.pk = 'test'
-    #         mock._headers = {HTTP_CONTENT_TYPE: 'application/json;'}
-    #         mock.content = b'invalid json'
-    #         mock.get = mock._headers.get
-    #         factory = ResponseModelFactory(mock)
-    #         body, content = factory.body()
-    #         self.assertEqual(body, '')

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -27,17 +27,6 @@ content_type_html = ['text/html']
 content_type_css = ['text/css']
 
 
-def _get_response_headers(response):
-    """
-    Django 3.2 (more specifically, commit bcc2befd0e9c1885e45b46d0b0bcdc11def8b249) broke the usage of _headers, which
-    were turned into a public interface, so we need this compatibility wrapper.
-    """
-    try:
-        return response.headers
-    except AttributeError:
-        return response._headers
-
-
 class DefaultEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, UUID):
@@ -322,9 +311,8 @@ class ResponseModelFactory:
             % self.request.pk
         )
         b, content = self.body()
-        raw_headers = _get_response_headers(self.response)
         headers = {}
-        for k, v in raw_headers.items():
+        for k, v in self.response.headers.items():
             try:
                 header, val = v
             except ValueError:


### PR DESCRIPTION
django-silk doesn't support django<3.2 anymore.  Therefore, the `_get_response_headers` function that provides compatibility with django<3.2 isn't needed.