### PR TITLE
Get paginator limit from url params

### DIFF
--- a/silk/utils/pagination.py
+++ b/silk/utils/pagination.py
@@ -4,7 +4,8 @@ __author__ = 'mtford'
 
 
 def _page(request, query_set):
-    paginator = Paginator(query_set, 200)
+    per_page = request.GET.get('per_page', 200)
+    paginator = Paginator(query_set, per_page)
     page_number = request.GET.get('page')
     try:
         page = paginator.page(page_number)


### PR DESCRIPTION
When profiling requests with a huge number of queries sometimes we end up with multiple pages. Since the sql page only sorts current lines it's hard to see all the heaviest queries on one page and there's no way to see more than 200 since the limit is hardcoded. 

This will allow the user to specify a page size via URL param e.g. `&per_page=300`.