### PR TITLE
Allow option to delete profiles

### DIFF
--- a/project/tests/test_view_clear_db.py
+++ b/project/tests/test_view_clear_db.py
@@ -20,3 +20,18 @@ class TestViewClearDB(TestCase):
         response = self.client.post(silky_reverse("cleardb"), {"clear_all": "on"})
         self.assertTrue(response.status_code == 200)
         self.assertEqual(models.Request.objects.count(), 0)
+        
+class TestViewClearDBAndDeleteProfiles(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        SilkyConfig().SILKY_AUTHENTICATION = False
+        SilkyConfig().SILKY_AUTHORISATION = False
+        SilkyConfig().SILKY_DELETE_PROFILES = True
+
+    def test_clear_all_and_delete_profiles(self):
+        RequestMinFactory.create()
+        self.assertEqual(models.Request.objects.count(), 1)
+        response = self.client.post(silky_reverse("cleardb"), {"clear_all": "on"})
+        self.assertTrue(response.status_code == 200)
+        self.assertEqual(models.Request.objects.count(), 0)

--- a/project/tests/test_view_clear_db.py
+++ b/project/tests/test_view_clear_db.py
@@ -20,7 +20,8 @@ class TestViewClearDB(TestCase):
         response = self.client.post(silky_reverse("cleardb"), {"clear_all": "on"})
         self.assertTrue(response.status_code == 200)
         self.assertEqual(models.Request.objects.count(), 0)
-        
+
+
 class TestViewClearDBAndDeleteProfiles(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/silk/config.py
+++ b/silk/config.py
@@ -33,7 +33,8 @@ class SilkyConfig(metaclass=Singleton):
         'SILKY_JSON_ENSURE_ASCII': True,
         'SILKY_ANALYZE_QUERIES': False,
         'SILKY_EXPLAIN_FLAGS': None,
-        'SILKY_SENSITIVE_KEYS': {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'}
+        'SILKY_SENSITIVE_KEYS': {'username', 'api', 'token', 'key', 'secret', 'password', 'signature'},
+        'SILKY_DELETE_PROFILES': False
     }
 
     def _setup(self):

--- a/silk/templates/silk/clear_db.html
+++ b/silk/templates/silk/clear_db.html
@@ -36,7 +36,7 @@
                 </div>
                 <button class="btn">Clear</button>
             </form>
-            <div class="msg">{{ msg }}</div>
+            <div class="msg">{{ msg|linebreaks }}</div>
         </div>
     </div>
 

--- a/silk/views/clear_db.py
+++ b/silk/views/clear_db.py
@@ -1,13 +1,15 @@
-import os, shutil
+import os
+import shutil
+
 from django.db import transaction
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 
 from silk.auth import login_possibly_required, permissions_possibly_required
+from silk.config import SilkyConfig
 from silk.models import Profile, Request, Response, SQLQuery
 from silk.utils.data_deletion import delete_model
-from silk.config import SilkyConfig
 
 
 @method_decorator(transaction.non_atomic_requests, name="dispatch")

--- a/silk/views/clear_db.py
+++ b/silk/views/clear_db.py
@@ -1,3 +1,4 @@
+import os, shutil
 from django.db import transaction
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
@@ -6,6 +7,7 @@ from django.views.generic import View
 from silk.auth import login_possibly_required, permissions_possibly_required
 from silk.models import Profile, Request, Response, SQLQuery
 from silk.utils.data_deletion import delete_model
+from silk.config import SilkyConfig
 
 
 @method_decorator(transaction.non_atomic_requests, name="dispatch")
@@ -27,4 +29,15 @@ class ClearDBView(View):
             delete_model(Request)
             tables = ['Response', 'SQLQuery', 'Profile', 'Request']
             context['msg'] = 'Cleared data for following silk tables: {}'.format(', '.join(tables))
+
+            if SilkyConfig().SILKY_DELETE_PROFILES:
+                dir = SilkyConfig().SILKY_PYTHON_PROFILER_RESULT_PATH
+                for files in os.listdir(dir):
+                    path = os.path.join(dir, files)
+                    try:
+                        shutil.rmtree(path)
+                    except OSError:
+                        os.remove(path)
+                context['msg'] += '\nDeleted all profiles from the directory.'
+
         return render(request, 'silk/clear_db.html', context=context)


### PR DESCRIPTION
Added a new config option that will allow user to clear profiler profiles from storage when Clear DB is called. This is helpful functionality especially in development environment where frequent DB cleaning is done.