### PR TITLE
Allow to use explain flags without analyze

### DIFF
--- a/project/tests/test_execute_sql.py
+++ b/project/tests/test_execute_sql.py
@@ -59,6 +59,23 @@ class TestCallNoRequest(TestCase):
         self.assertEqual(0, len(DataCollector().queries))
 
 
+class TestCallInvalidExplainFlags(TestCase):
+    def setUp(self):
+        super().setUp()
+        with self.settings(SILKY_EXPLAIN_FLAGS={"invalid": "setting"}):
+            call_execute_sql(type(self), Request())
+
+    def test_called(self):
+        self.mock_sql._execute_sql.assert_called_once_with(*self.args, **self.kwargs)
+
+    def test_count(self):
+        self.assertEqual(1, len(DataCollector().queries))
+
+    def test_query(self):
+        query = list(DataCollector().queries.values())[0]
+        self.assertEqual(query['query'], self.query_string)
+
+
 class TestCallRequest(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/silk/sql.py
+++ b/silk/sql.py
@@ -61,6 +61,7 @@ def _explain_query(connection, q, params):
         result = _unpack_explanation(cur.fetchall())
         return '\n'.join(result)
 
+
 def execute_sql(self, *args, **kwargs):
     """wrapper around real execute_sql in order to extract information"""
 


### PR DESCRIPTION
In #558 support for specifying `EXPLAIN` flags was introduced, as requested in #530. However it only works when setting `SILKY_ANALYZE_QUERIES` to `True`.

I don't want to use `EXPLAIN ANALYZE` but would like to use `SILKY_EXPLAIN_FLAGS` with `EXPLAIN` which is currently impossible.

This PR is a proposal to allow such a behaviour.