### PR TITLE
execute_sql: fix DjangoUnicodeDecodeError being raised

### DIFF
--- a/silk/sql.py
+++ b/silk/sql.py
@@ -77,7 +77,7 @@ def execute_sql(self, *args, **kwargs):
             return iter([])
         else:
             return
-    sql_query = q % tuple(force_str(param) for param in params)
+    sql_query = q % tuple(force_str(param, errors="backslashreplace") for param in params)
     if _should_wrap(sql_query):
         tb = ''.join(reversed(traceback.format_stack()))
         query_dict = {


### PR DESCRIPTION
The aim of this pull request is to prevent an exception from being raised when profiling an SQL query that contains parameters which are arbitrary bytes.

Queries that contain parameters that are bytes can still raise DjangoUnicodeDecodeError if the codec cannot decode the bytes. This is because `force_str()` uses 'strict' mode by default.
This fix permanently solves issue #157.

### Before

```
>>> force_str(b'some query with \xb4')
Traceback (most recent call last):
  File "/lib/python3.9/site-packages/django/utils/encoding.py", line 62, in force_str
    s = str(s, encoding, errors)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb4 in position 16: invalid start byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/python3.9/site-packages/django/utils/encoding.py", line 66, in force_str
    raise DjangoUnicodeDecodeError(s, *e.args)
django.utils.encoding.DjangoUnicodeDecodeError: 'utf-8' codec can't decode byte 0xb4 in position 16: invalid start byte. You passed in b'some query with \xb4' (<class 'bytes'>)
```

### After

```
>>> force_str(b'some query with \xb4', errors="backslashreplace")
'some query with \\xb4'
```