### PR TITLE
Add a "pagetitle" block to Silky templates

### DIFF
--- a/silk/templates/silk/base/base.html
+++ b/silk/templates/silk/base/base.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Silky</title>
+    <title>{% block pagetitle %}Silky{% endblock %}</title>
     <link rel="stylesheet" href="{% static "silk/css/components/fonts.css" %}"/>
     <link rel="stylesheet" href="{% static "silk/css/components/colors.css" %}"/>
     <link rel="stylesheet" href="{% static "silk/lib/jquery-ui-1.13.1.min.css" %}"/>

--- a/silk/templates/silk/clear_db.html
+++ b/silk/templates/silk/clear_db.html
@@ -1,6 +1,8 @@
 {% extends 'silk/base/root_base.html' %}
 {% load silk_inclusion %}
 {% load static %}
+{% block pagetitle %}Silky - Clear DB{% endblock %}
+
 {% block menu %}
     {% root_menu request %}
 {% endblock %}

--- a/silk/templates/silk/cprofile.html
+++ b/silk/templates/silk/cprofile.html
@@ -4,7 +4,7 @@
 {% load silk_inclusion %}
 {% load static %}
 
-{% block pagetitle %}Silky - CProfile{% endblock %}
+{% block pagetitle %}Silky - CProfile - {{ silk_request.path }}{% endblock %}
 
 {% block js %}
     <script type="text/javascript" src="{% static 'silk/lib/viz-lite.js' %}"></script>

--- a/silk/templates/silk/cprofile.html
+++ b/silk/templates/silk/cprofile.html
@@ -4,6 +4,8 @@
 {% load silk_inclusion %}
 {% load static %}
 
+{% block pagetitle %}Silky - CProfile{% endblock %}
+
 {% block js %}
     <script type="text/javascript" src="{% static 'silk/lib/viz-lite.js' %}"></script>
     <script type="text/javascript" src="{% static 'silk/lib/svg-pan-zoom.min.js' %}"></script>
@@ -23,7 +25,7 @@
 
 {% block data %}
     <div class="wrapper">
-        <div id="query-div">           
+        <div id="query-div">
             {% if silk_request.pyprofile %}
             <div id="pyprofile-div">
                 <div class="heading">

--- a/silk/templates/silk/profile_detail.html
+++ b/silk/templates/silk/profile_detail.html
@@ -4,7 +4,7 @@
 {% load silk_inclusion %}
 {% load static %}
 
-{% block pagetitle %}Silky - Profile Detail{% endblock %}
+{% block pagetitle %}Silky - Profile Detail - {{ silk_request.path }}{% endblock %}
 
 {% block js %}
     <script type="text/javascript" src="{% static 'silk/lib/viz-lite.js' %}"></script>

--- a/silk/templates/silk/profile_detail.html
+++ b/silk/templates/silk/profile_detail.html
@@ -4,6 +4,8 @@
 {% load silk_inclusion %}
 {% load static %}
 
+{% block pagetitle %}Silky - Profile Detail{% endblock %}
+
 {% block js %}
     <script type="text/javascript" src="{% static 'silk/lib/viz-lite.js' %}"></script>
     <script type="text/javascript" src="{% static 'silk/lib/svg-pan-zoom.min.js' %}"></script>

--- a/silk/templates/silk/profiling.html
+++ b/silk/templates/silk/profiling.html
@@ -2,6 +2,8 @@
 {% load static %}
 {% load silk_inclusion %}
 
+{% block pagetitle %}Silky - Profiling{% endblock %}
+
 {% block menu %}
     {% if silk_request %}
         {% request_menu request silk_request %}

--- a/silk/templates/silk/profiling.html
+++ b/silk/templates/silk/profiling.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load silk_inclusion %}
 
-{% block pagetitle %}Silky - Profiling{% endblock %}
+{% block pagetitle %}Silky - Profiling - {{ silk_request.path }}{% endblock %}
 
 {% block menu %}
     {% if silk_request %}

--- a/silk/templates/silk/request.html
+++ b/silk/templates/silk/request.html
@@ -2,7 +2,7 @@
 {% load silk_filters %}
 {% load silk_inclusion %}
 {% load static %}
-{% block pagetitle %}Silky - Request{% endblock %}
+{% block pagetitle %}Silky - Request - {{ silk_request.path }}{% endblock %}
 
 {% block style %}
     <link rel="stylesheet" href="{% static 'silk/css/components/cell.css' %}"/>

--- a/silk/templates/silk/request.html
+++ b/silk/templates/silk/request.html
@@ -2,6 +2,8 @@
 {% load silk_filters %}
 {% load silk_inclusion %}
 {% load static %}
+{% block pagetitle %}Silky - Request{% endblock %}
+
 {% block style %}
     <link rel="stylesheet" href="{% static 'silk/css/components/cell.css' %}"/>
     <link rel="stylesheet" href="{% static 'silk/css/components/numeric.css' %}"/>

--- a/silk/templates/silk/requests.html
+++ b/silk/templates/silk/requests.html
@@ -2,6 +2,8 @@
 {% load silk_inclusion %}
 {% load static %}
 
+{% block pagetitle %}Silky - Requests{% endblock %}
+
 {% block style %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'silk/css/pages/requests.css' %}"/>

--- a/silk/templates/silk/sql.html
+++ b/silk/templates/silk/sql.html
@@ -5,6 +5,8 @@
 {% load static %}
 {% load silk_inclusion %}
 
+{% block pagetitle %}Silky - SQL{% endblock %}
+
 {% block js %}
   <script type="text/javascript" src="{% static 'silk/lib/sortable.js' %}"></script>
   {{ block.super }}

--- a/silk/templates/silk/sql.html
+++ b/silk/templates/silk/sql.html
@@ -5,7 +5,7 @@
 {% load static %}
 {% load silk_inclusion %}
 
-{% block pagetitle %}Silky - SQL{% endblock %}
+{% block pagetitle %}Silky - SQL - {{ silk_request.path }}{% endblock %}
 
 {% block js %}
   <script type="text/javascript" src="{% static 'silk/lib/sortable.js' %}"></script>

--- a/silk/templates/silk/sql_detail.html
+++ b/silk/templates/silk/sql_detail.html
@@ -4,7 +4,7 @@
 {% load silk_nav %}
 {% load silk_inclusion %}
 
-{% block pagetitle %}Silky - SQL Detail{% endblock %}
+{% block pagetitle %}Silky - SQL Detail - {{ silk_request.path }}{% endblock %}
 
 {% block js %}
     {{ block.super }}

--- a/silk/templates/silk/sql_detail.html
+++ b/silk/templates/silk/sql_detail.html
@@ -4,6 +4,8 @@
 {% load silk_nav %}
 {% load silk_inclusion %}
 
+{% block pagetitle %}Silky - SQL Detail{% endblock %}
+
 {% block js %}
     {{ block.super }}
     <script src="{% static 'silk/js/pages/sql_detail.js' %}"></script>

--- a/silk/templates/silk/summary.html
+++ b/silk/templates/silk/summary.html
@@ -5,6 +5,8 @@
     {% root_menu request %}
 {% endblock %}
 
+{% block pagetitle %}Silky - Summary{% endblock %}
+
 {% block style %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'silk/css/pages/summary.css' %}"/>


### PR DESCRIPTION
Add a "pagetitle" block to Silky templates so that when multiple Silky browser tabs are open, it's easier to tell which is which.