### PR TITLE
Fix when Session, Authentication or Message middlewares are not present

### DIFF
--- a/project/tests/test_view_summary_view.py
+++ b/project/tests/test_view_summary_view.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 
+from silk.middleware import silky_reverse
 from silk.views.summary import SummaryView
 
+from .test_lib.assertion import dict_contains
 from .test_lib.mock_suite import MockSuite
 
 mock_suite = MockSuite()
@@ -11,3 +13,27 @@ class TestSummaryView(TestCase):
     def test_longest_query_by_view(self):
         [mock_suite.mock_request() for _ in range(0, 10)]
         print([x.time_taken for x in SummaryView()._longest_query_by_view([])])
+
+    def test_view_without_session_and_auth_middlewares(self):
+        """
+        Filters are not present because there is no `session` to store them.
+        """
+        with self.modify_settings(MIDDLEWARE={
+            'remove': [
+                'django.contrib.sessions.middleware.SessionMiddleware',
+                'django.contrib.auth.middleware.AuthenticationMiddleware',
+                'django.contrib.messages.middleware.MessageMiddleware',
+            ],
+        }):
+            # test filters on POST
+            seconds = 3600
+            response = self.client.post(silky_reverse('summary'), {
+                'filter-seconds-value': seconds,
+                'filter-seconds-typ': 'SecondsFilter',
+            })
+            context = response.context
+            self.assertTrue(dict_contains({
+                'filters': {
+                    'seconds': {'typ': 'SecondsFilter', 'value': seconds, 'str': f'>{seconds} seconds ago'}
+                }
+            }, context))

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -1,13 +1,16 @@
 import logging
 import random
 
+from django.conf import settings
 from django.db import DatabaseError, transaction
 from django.db.models.sql.compiler import SQLCompiler
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from silk.collector import DataCollector
 from silk.config import SilkyConfig
+from silk.errors import SilkNotConfigured
 from silk.model_factory import RequestModelFactory, ResponseModelFactory
 from silk.profiling import dynamic
 from silk.profiling.profiler import silk_meta_profiler
@@ -32,6 +35,11 @@ def get_fpath():
 
 
 config = SilkyConfig()
+AUTH_AND_SESSION_MIDDLEWARES = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
 
 
 def _should_intercept(request):
@@ -64,10 +72,24 @@ class TestMiddleware:
 
 class SilkyMiddleware:
     def __init__(self, get_response):
+        if config.SILKY_AUTHENTICATION and not (
+            set(AUTH_AND_SESSION_MIDDLEWARES) & set(settings.MIDDLEWARE)
+        ):
+            raise SilkNotConfigured(
+                _("SILKY_AUTHENTICATION can not be enabled without Session, "
+                  "Authentication or Message Django's middlewares")
+            )
+
         self.get_response = get_response
 
     def __call__(self, request):
         self.process_request(request)
+
+        # To be able to persist filters when Session and Authentication
+        # middlewares are not present.
+        # Unlike session (which stores in DB) it won't persist filters
+        # after refresh the page.
+        request.silk_filters = {}
 
         response = self.get_response(request)
 

--- a/silk/request_filters.py
+++ b/silk/request_filters.py
@@ -230,3 +230,18 @@ def filters_from_request(request):
             except FilterValidationError:
                 logger.warning(f'Validation error when processing filter {typ}({value})')
     return filters
+
+
+class FiltersManager:
+    def __init__(self, filters_key):
+        self.key = filters_key
+
+    def save(self, request, filters):
+        if hasattr(request, 'session'):
+            request.session[self.key] = filters
+        request.silk_filters = filters
+
+    def get(self, request):
+        if hasattr(request, 'session'):
+            return request.session.get(self.key, {})
+        return request.silk_filters


### PR DESCRIPTION
Hello!

In this PR I try fix the issue https://github.com/jazzband/django-silk/issues/347

Doesn't fail when one of these middlewares are not present:
```
'django.contrib.sessions.middleware.SessionMiddleware',
'django.contrib.auth.middleware.AuthenticationMiddleware',
'django.contrib.messages.middleware.MessageMiddleware'
```

and if `SILKY_AUTHENTICATION` is `True`, an exception is raised: **SILKY_AUTHENTICATION can not be enabled without Session, Authentication or Message Django's middlewares**

Let me know any change required!

Thank you!