### PR TITLE
Fix deprecation warning for get_storage_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ When enabled, a graph visualisation generated using [gprof2dot](https://github.c
 A custom storage class can be used for the saved generated binary `.prof` files:
 
 ```python
+# For Django >= 4.2 and Django-Silk >= 5.1.0:
+# See https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-STORAGES
+STORAGES = {
+    'SILKY_STORAGE': {
+        'BACKEND': 'path.to.StorageClass',
+    },
+    # ...
+}
+
+# For Django < 4.2 or Django-Silk < 5.1.0
 SILKY_STORAGE_CLASS = 'path.to.StorageClass'
 ```
 


### PR DESCRIPTION
This PR should fix the deprecation warning for `get_storage_class` by trying to import and use the `storages` class instead.  However, the latter is not an exact replacement for the former, requiring a different configuration option to be provided under the `STORAGE` instead of the `SILKY_STORAGE_CLASS` setting.  This makes this PR a forwards incompatible change requiring a minor semver bump.

Fixes #656 