### PR TITLE
Remove deprecated django.utils.timezone.utc

### DIFF
--- a/project/tests/test_filters.py
+++ b/project/tests/test_filters.py
@@ -1,11 +1,11 @@
 import calendar
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from itertools import groupby
 from math import floor
 
 from django.test import TestCase
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from silk import models
 from silk.request_filters import (
@@ -41,13 +41,13 @@ class TestRequestFilters(TestCase):
         requests = [mock_suite.mock_request() for _ in range(0, 10)]
         n = 0
         for r in requests:
-            r.start_time = timezone.now() - timedelta(seconds=n)
+            r.start_time = django_timezone.now() - timedelta(seconds=n)
             r.save()
             n += 1
         requests = models.Request.objects.filter(SecondsFilter(5))
         for r in requests:
             dt = r.start_time
-            seconds = self._time_stamp(timezone.now()) - self._time_stamp(dt)
+            seconds = self._time_stamp(django_timezone.now()) - self._time_stamp(dt)
             self.assertTrue(seconds < 6)  # 6 to give a bit of leeway in case takes too long
 
     def test_view_name_filter(self):
@@ -147,7 +147,7 @@ class TestRequestAfterDateFilter(TestCase):
         date_filter = AfterDateFilter
         f = date_filter(dt_str)
         new_dt = datetime.strptime(dt_str, fmt)
-        new_dt = timezone.make_aware(new_dt, timezone.utc)
+        new_dt = django_timezone.make_aware(new_dt, timezone.utc)
         self.assertFilter(new_dt, f)
 
 
@@ -176,7 +176,7 @@ class TestRequestBeforeDateFilter(TestCase):
         date_filter = BeforeDateFilter
         f = date_filter(dt_str)
         new_dt = datetime.strptime(dt_str, fmt)
-        new_dt = timezone.make_aware(new_dt, timezone.utc)
+        new_dt = django_timezone.make_aware(new_dt, timezone.utc)
         self.assertFilter(new_dt, f)
 
 

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -3,7 +3,6 @@ import uuid
 
 from django.core.management import call_command
 from django.test import TestCase, override_settings
-from django.utils import timezone
 from freezegun import freeze_time
 
 from silk import models
@@ -45,7 +44,7 @@ class RequestTest(TestCase):
     def test_start_time_field_default(self):
 
         obj = RequestMinFactory.create()
-        self.assertEqual(obj.start_time, datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(obj.start_time, datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc))
 
     def test_total_meta_time_if_have_no_meta_and_queries_time(self):
 
@@ -185,7 +184,7 @@ class RequestTest(TestCase):
     @freeze_time('2016-01-01 12:00:00')
     def test_save_if_have_end_time(self):
 
-        date = datetime.datetime(2016, 1, 1, 12, 0, 3, tzinfo=timezone.utc)
+        date = datetime.datetime(2016, 1, 1, 12, 0, 3, tzinfo=datetime.timezone.utc)
         obj = models.Request(path='/some/path/', method='get', end_time=date)
         obj.save()
         self.assertEqual(obj.end_time, date)
@@ -262,14 +261,14 @@ class SQLQueryTest(TestCase):
     def setUp(self):
 
         self.obj = SQLQueryFactory.create()
-        self.end_time = datetime.datetime(2016, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
-        self.start_time = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        self.end_time = datetime.datetime(2016, 1, 1, 12, 0, 5, tzinfo=datetime.timezone.utc)
+        self.start_time = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
 
     @freeze_time('2016-01-01 12:00:00')
     def test_start_time_field_default(self):
 
         obj = SQLQueryFactory.create()
-        self.assertEqual(obj.start_time, datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(obj.start_time, datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc))
 
     def test_is_m2o_related_to_request(self):
 
@@ -432,7 +431,7 @@ class SQLQueryTest(TestCase):
     @freeze_time('2016-01-01 12:00:00')
     def test_save_if_has_end_time(self):
 
-        # datetime.datetime(2016, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
+        # datetime.datetime(2016, 1, 1, 12, 0, 5, tzinfo=datetime.timezone.utc)
         obj = SQLQueryFactory.create(end_time=self.end_time)
 
         self.assertEqual(obj.time_taken, 5000.0)


### PR DESCRIPTION
`django.utils.timezone.utc` is deprecated and should be replaced with `datetime.timezone.utc` which exists in all versions of python supported by django-silk.  