### PR TITLE
Derive version from importlib

### DIFF
--- a/silk/__init__.py
+++ b/silk/__init__.py
@@ -1,6 +1,3 @@
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version
 
-try:
-    __version__ = get_distribution("django-silk").version
-except DistributionNotFound:
-    pass
+__version__ = version("django-silk")


### PR DESCRIPTION
This removes the dependency on setuptools, which is no longer automatically installed in virtual environments starting in Python 3.12.