### PR TITLE
Always disable cProfile as part of cleanup

### DIFF
--- a/project/tests/test_execute_sql.py
+++ b/project/tests/test_execute_sql.py
@@ -52,6 +52,9 @@ class TestCallNoRequest(TestCase):
         super().setUpClass()
         call_execute_sql(cls, None)
 
+    def tearDown(self):
+        DataCollector().stop_python_profiler()
+
     def test_called(self):
         self.mock_sql._execute_sql.assert_called_once_with(*self.args, **self.kwargs)
 
@@ -65,6 +68,9 @@ class TestCallRequest(TestCase):
         super().setUpClass()
         call_execute_sql(cls, Request())
 
+    def tearDown(self):
+        DataCollector().stop_python_profiler()
+
     def test_called(self):
         self.mock_sql._execute_sql.assert_called_once_with(*self.args, **self.kwargs)
 
@@ -77,6 +83,9 @@ class TestCallRequest(TestCase):
 
 
 class TestCallSilky(TestCase):
+    def tearDown(self):
+        DataCollector().stop_python_profiler()
+
     def test_no_effect(self):
         DataCollector().configure()
         sql, _ = mock_sql()
@@ -89,6 +98,9 @@ class TestCallSilky(TestCase):
 
 
 class TestCollectorInteraction(TestCase):
+    def tearDown(self):
+        DataCollector().stop_python_profiler()
+
     def _query(self):
         try:
             query = list(DataCollector().queries.values())[0]

--- a/silk/collector.py
+++ b/silk/collector.py
@@ -59,6 +59,7 @@ class DataCollector(metaclass=Singleton):
     def _configure(self):
         self.local.objects = {}
         self.local.temp_identifier = 0
+        self.stop_python_profiler()
         self.local.pythonprofiler = None
 
     @property


### PR DESCRIPTION
As a followup to #692 , this diff cleans up two places where cProfile is enabled but not disabled.  

In `collector.py`, the `DataCollector()._configure()` logic is changed so that the profiler is explicitly stopped before the profiler is set to `None`.  If the profile is set to `None`, future profiles are blocked even though the old profiler is not accessible and pending garbage collection.

In `test_execute_sql.py`, the test cases are enabling profiling through `DataCollector` but the test cases are not explicitly disabling profiling when finished.  This causes other test cases to fail when they attempt to profile.  (I'm not sure why these test cases explicitly require disabling profiling even though many other test cases also initialize `DataCollector` and enable profiling)

#692 should have caught this but it turns out that `tox.ini` is configured to [ignore djmain](https://github.com/albertyw/django-silk/blob/5.0.4/tox.ini#L22-L23) and by extension due to the test version matrix, most python 3.12 failures.