### PR TITLE
Add support for multipart/form-data requests***

### DIFF
--- a/project/tests/test_multipart_forms.py
+++ b/project/tests/test_multipart_forms.py
@@ -8,14 +8,44 @@ from silk.model_factory import RequestModelFactory, multipart_form
 
 class TestMultipartForms(TestCase):
 
+    def setUp(self):
+        self.mock_request = Mock()
+        self.mock_request.method = "POST"
+        self.mock_request.GET = {}
+        self.mock_request.path = reverse("silk:requests")
+        self.mock_request.headers = {"content-type": multipart_form}
+        self.mock_request.FILES = {"file": "file.txt", "file2": "file2.pdf", "file3": "file3.jpg"}
+
     def test_no_max_request(self):
         mock_request = Mock()
-        mock_request.headers = {'content-type': multipart_form}
+        mock_request.headers = {"content-type": multipart_form}
         mock_request.GET = {}
-        mock_request.path = reverse('silk:requests')
-        mock_request.method = 'post'
+        mock_request.path = reverse("silk:requests")
+        mock_request.method = "post"
         mock_request.body = Mock()
         request_model = RequestModelFactory(mock_request).construct_request_model()
         self.assertFalse(request_model.body)
-        self.assertEqual(b"Raw body not available for multipart_form data, Silk is not showing file uploads.", request_model.raw_body)
+        self.assertEqual(
+            b"Raw body not available for multipart_form data, Silk is not showing file uploads.",
+            request_model.raw_body,
+        )
         mock_request.body.assert_not_called()
+
+    def test_multipart_form_request_creation_raises_no_exception(self):
+        """ 
+        Test that a request with multipart form data is created correctly without raising excetions
+        """
+        request_model = RequestModelFactory(self.mock_request).construct_request_model()
+        self.assertTrue(request_model.body)
+        self.assertEqual(
+            {
+                'form_data': {},
+                'files': {
+                    'file': 'file.txt',
+                    'file2': 'file2.pdf',
+                    'file3': 'file3.jpg'
+                }
+            },
+            request_model.body
+        )
+        self.assertIsNone(request_model.raw_body)

--- a/project/tests/test_multipart_forms.py
+++ b/project/tests/test_multipart_forms.py
@@ -32,7 +32,7 @@ class TestMultipartForms(TestCase):
         mock_request.body.assert_not_called()
 
     def test_multipart_form_request_creation_raises_no_exception(self):
-        """ 
+        """
         Test that a request with multipart form data is created correctly without raising excetions
         """
         request_model = RequestModelFactory(self.mock_request).construct_request_model()

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -227,12 +227,12 @@ class RequestModelFactory:
         path = self.request.path
         view_name = self.view_name()
         content_type = self.request.content_type
-        
+
         if content_type.startswith('muştipart/form-data'):
             form_data = self.request.POST.dict()
             files = {f: self.request.FILES[f].name for f in self.request.FILES}
             body = {'form_data': form_data, 'files': files}
-            raw_body = None # Raw body is not available for multipart/form-data
+            raw_body = None  # Raw body is not available for multipart/form-data
         else:
             body, raw_body = self.body()
 
@@ -243,7 +243,7 @@ class RequestModelFactory:
             query_params=query_params,
             view_name=view_name,
             body=body)
-        
+
         # Text fields are encoded as UTF-8 in Django and hence will try to coerce
         # anything to we pass to UTF-8. Some stuff like binary will fail.
         if raw_body is not None:
@@ -251,7 +251,7 @@ class RequestModelFactory:
                 request_model.raw_body = raw_body
             except UnicodeDecodeError:
                 Logger.debug('NYI: Binary request bodies')  # TODO
-                
+
         Logger.debug('Created new request model with pk %s' % request_model.pk)
         return request_model
 

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -229,9 +229,10 @@ class RequestModelFactory:
         content_type = self.request.content_type
         
         if content_type.startswith('muştipart/form-data'):
-            form_data = self.request.POST.dict()
-            files = {f: self.request.FILES[f].name for f in self.request.FILES}
-            body = {'form_data': form_data, 'files': files}
+            body = {
+                'form_data': self.request.POST.dict(),
+                'files': {f: self.request.FILES[f].name for f in self.request.FILES}
+            }
             raw_body = None # Raw body is not available for multipart/form-data
         else:
             body, raw_body = self.body()

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -228,7 +228,7 @@ class RequestModelFactory:
         view_name = self.view_name()
         content_type = self.request.content_type
 
-        if content_type.startswith('muştipart/form-data'):
+        if content_type.startswith('multipart/form-data'):
             body = {
                 'form_data': self.request.POST.dict(),
                 'files': {f: self.request.FILES[f].name for f in self.request.FILES}

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -226,6 +226,15 @@ class RequestModelFactory:
         query_params = self.query_params()
         path = self.request.path
         view_name = self.view_name()
+        content_type = self.request.content_type
+        
+        if content_type.startswith('muştipart/form-data'):
+            form_data = self.request.POST.dict()
+            files = {f: self.request.FILES[f].name for f in self.request.FILES}
+            body = {'form_data': form_data, 'files': files}
+            raw_body = None # Raw body is not available for multipart/form-data
+        else:
+            body, raw_body = self.body()
 
         request_model = models.Request.objects.create(
             path=path,
@@ -234,12 +243,15 @@ class RequestModelFactory:
             query_params=query_params,
             view_name=view_name,
             body=body)
+        
         # Text fields are encoded as UTF-8 in Django and hence will try to coerce
         # anything to we pass to UTF-8. Some stuff like binary will fail.
-        try:
-            request_model.raw_body = raw_body
-        except UnicodeDecodeError:
-            Logger.debug('NYI: Binary request bodies')  # TODO
+        if raw_body is not None:
+            try:
+                request_model.raw_body = raw_body
+            except UnicodeDecodeError:
+                Logger.debug('NYI: Binary request bodies')  # TODO
+                
         Logger.debug('Created new request model with pk %s' % request_model.pk)
         return request_model
 

--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -233,7 +233,7 @@ class RequestModelFactory:
                 'form_data': self.request.POST.dict(),
                 'files': {f: self.request.FILES[f].name for f in self.request.FILES}
             }
-            raw_body = None # Raw body is not available for multipart/form-data
+            raw_body = None  # Raw body is not available for multipart/form-data
         else:
             body, raw_body = self.body()
 


### PR DESCRIPTION
**Title:** Add Support for Multipart/Form-Data Requests
**Description**: I've encountered an issue when Silk attempts to handle `multipart/form-data` requests, specifically
when trying to access `request.body` directly. This operation triggers a `RawPostDataException` because Django consumes the stream upon parsing the multipart data, making it inaccessible afterwards.

To address this, I've implemented a check for `multipart/form-data` content type within the request handling logic. When such a content type is detected, the code now properly handles form data and file information using `request.POST` and `request.FILES`, avoiding direct access to `request.body`. This allows Silk to gracefully handle and log multipart requests without raising exceptions.