### PR TITLE
Fix double-escaping of the curl and Python example code

### DIFF
--- a/project/tests/test_code_gen_curl.py
+++ b/project/tests/test_code_gen_curl.py
@@ -1,0 +1,23 @@
+import shlex
+import textwrap
+from unittest import TestCase
+
+from silk.code_generation.curl import curl_cmd
+
+class TestCodeGenCurl(TestCase):
+    def test_post_json(self):
+        result = curl_cmd(
+            url="https://example.org/alpha/beta",
+            method="POST",
+            body={"gamma": "delta"},
+            content_type="application/json",
+        )
+
+        result_words = shlex.split(result)
+
+        self.assertEqual(result_words, [
+            'curl', '-X', 'POST',
+            '-H', 'content-type: application/json',
+            '-d', '{"gamma": "delta"}',
+            'https://example.org/alpha/beta'
+        ])

--- a/project/tests/test_code_gen_curl.py
+++ b/project/tests/test_code_gen_curl.py
@@ -1,8 +1,8 @@
 import shlex
-import textwrap
 from unittest import TestCase
 
 from silk.code_generation.curl import curl_cmd
+
 
 class TestCodeGenCurl(TestCase):
     def test_post_json(self):

--- a/project/tests/test_code_gen_django.py
+++ b/project/tests/test_code_gen_django.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from silk.code_generation.django_test_client import gen
 
+
 class TestCodeGenDjango(TestCase):
     def test_post(self):
         result = gen(

--- a/project/tests/test_code_gen_django.py
+++ b/project/tests/test_code_gen_django.py
@@ -1,6 +1,21 @@
-from django.test import TestCase
+import textwrap
+from unittest import TestCase
 
+from silk.code_generation.django_test_client import gen
 
 class TestCodeGenDjango(TestCase):
+    def test_post(self):
+        result = gen(
+            path="/alpha/beta",
+            method="POST",
+            data={"gamma": "delta", "epsilon": "zeta"},
+            content_type="application/x-www-form-urlencoded",
+        )
 
-    pass
+        self.assertEqual(result, textwrap.dedent("""\
+            from django.test import Client
+            c = Client()
+            response = c.post(path='/alpha/beta',
+                              data={'gamma': 'delta', 'epsilon': 'zeta'},
+                              content_type='application/x-www-form-urlencoded')
+        """))

--- a/silk/code_generation/curl.py
+++ b/silk/code_generation/curl.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 
 from django.template import Context, Template
 
-curl_template = """
+curl_template = """\
 curl {% if method %}-X {{ method }}{% endif %}
 {% if content_type %}-H 'content-type: {{ content_type }}'{% endif %}
 {% if modifier %}{{ modifier }} {% endif %}{% if body %}'{{ body }}'{% endif %}
@@ -66,4 +66,4 @@ def curl_cmd(url, method=None, query_params=None, body=None, content_type=None):
         'content_type': content_type,
         'extra': extra,
     }
-    return t.render(Context(context)).replace('\n', ' ')
+    return t.render(Context(context, autoescape=False)).replace('\n', ' ')

--- a/silk/code_generation/django_test_client.py
+++ b/silk/code_generation/django_test_client.py
@@ -5,7 +5,7 @@ from django.template import Context, Template
 
 from silk.profiling.dynamic import is_str_typ
 
-template = """
+template = """\
 from django.test import Client
 c = Client()
 response = c.{{ lower_case_method }}(path='{{ path }}'{% if data or content_type %},{% else %}){% endif %}{% if data %}
@@ -43,6 +43,6 @@ def gen(path, method=None, query_params=None, data=None, content_type=None):
         context['data'] = data
         context['query_params'] = query_params
     return autopep8.fix_code(
-        t.render(Context(context)),
+        t.render(Context(context, autoescape=False)),
         options=autopep8.parse_args(['--aggressive', '']),
     )


### PR DESCRIPTION
These code fragments are escaped when they are substituted into the `silk/request.html` template, so they should not be escaped an extra time when they are constructed.

Fixes #688.