### PR TITLE
Enhance tables_involved Property to Include Tables from Update and Delete Operations

### DIFF
--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -422,6 +422,32 @@ class SQLQueryTest(TestCase):
         self.obj.query = query
         self.assertEqual(self.obj.tables_involved, ['bar', 'some_table;'])
 
+    def test_tables_involved_if_query_has_update_token(self):
+
+        query = """UPDATE Book SET title = 'New Title' WHERE id = 1;"""
+        self.obj.query = query
+        self.assertEqual(self.obj.tables_involved, ['Book'])
+
+    def test_tables_involved_in_complex_update_query(self):
+
+        query = '''UPDATE Person p
+                SET p.name = (SELECT c.name FROM Company c WHERE c.id = p.company_id),
+                    p.salary = p.salary * 1.1
+                FROM Department d
+                WHERE p.department_id = d.id AND d.budget > 100000;
+        '''
+        self.obj.query = query
+        self.assertEqual(self.obj.tables_involved, ['Person', 'Company', 'Department'])
+
+    def test_tables_involved_in_update_with_subquery(self):
+
+        query = '''UPDATE Employee e
+                SET e.bonus = (SELECT AVG(salary) FROM Employee WHERE department_id = e.department_id)
+                WHERE e.performance = 'excellent';
+        '''
+        self.obj.query = query
+        self.assertEqual(self.obj.tables_involved, ['Employee', 'Employee'])
+
     def test_save_if_no_end_and_start_time(self):
 
         obj = SQLQueryFactory.create()

--- a/silk/models.py
+++ b/silk/models.py
@@ -303,7 +303,12 @@ class SQLQuery(models.Model):
         for idx, component in enumerate(components):
             # TODO: If django uses aliases on column names they will be falsely
             # identified as tables...
-            if component.lower() == 'from' or component.lower() == 'join' or component.lower() == 'as':
+            if (
+                component.lower() == "from"
+                or component.lower() == "join"
+                or component.lower() == "as"
+                or component.lower() == "update"
+            ):
                 try:
                     _next = components[idx + 1]
                     if not _next.startswith('('):  # Subquery


### PR DESCRIPTION
This pull request addresses the issue where the `tables_involved` property of the SQLQuery model fails to recognize tables involved in UPDATE operation. The current implementation only captures tables involved in SELECT and JOIN operations.

The updated implementation includes UPDATE operation to ensure comprehensive table identification. The modified code is as follows:

```python
class SQLQuery(models.Model):
    query = TextField()
    ...

    @property
    def tables_involved(self):
        ...
        for idx, component in enumerate(components):
            ...
            if (
                component.lower() == "from"
                or component.lower() == "join"
                or component.lower() == "as"
                or component.lower() == "update"
            ):
                ...
        return tables
```

By including update statement, this change ensures that all relevant tables are captured for a more complete SQL query analysis. This update helps in better tracking and debugging of SQL queries within Django applications.

Fixes #716 