### PR TITLE
Remove old vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,6 @@ project/media/
 project/tmp/
 .vscode/
 
-# Vagrant
-.vagrant
-
 # Hardlinks
 /django_silky/silk
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,0 @@
-VAGRANTFILE_API_VERSION = "2"
-
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    config.vm.network "private_network", ip: "192.168.50.11"
-    config.vm.box = "precise64"
-    config.vm.box_url = "http://files.vagrantup.com/precise64.box"
-    config.ssh.forward_agent = true
-end


### PR DESCRIPTION
I don't think anybody uses this Vagrantfile which depends on a 12 year old version of Ubuntu.  There are no references to it in documentation or code.