### PR TITLE
Annotate time_taken fields as milliseconds rather than seconds

### DIFF
--- a/silk/models.py
+++ b/silk/models.py
@@ -83,7 +83,7 @@ class Request(models.Model):
         default='', null=True
     )
     end_time = DateTimeField(null=True, blank=True)
-    time_taken = FloatField(blank=True, null=True)
+    time_taken = FloatField(blank=True, null=True)  # milliseconds
     encoded_headers = TextField(blank=True, default='')  # stores json
     meta_time = FloatField(null=True, blank=True)
     meta_num_queries = IntegerField(null=True, blank=True)
@@ -252,7 +252,7 @@ class SQLQuery(models.Model):
     query = TextField()
     start_time = DateTimeField(null=True, blank=True, default=timezone.now)
     end_time = DateTimeField(null=True, blank=True)
-    time_taken = FloatField(blank=True, null=True)
+    time_taken = FloatField(blank=True, null=True)  # milliseconds
     identifier = IntegerField(default=-1)
     request = ForeignKey(
         Request, related_name='queries', null=True,
@@ -345,7 +345,7 @@ class BaseProfile(models.Model):
         Request, null=True, blank=True, db_index=True,
         on_delete=models.CASCADE,
     )
-    time_taken = FloatField(blank=True, null=True)
+    time_taken = FloatField(blank=True, null=True)  # milliseconds
 
     class Meta:
         abstract = True


### PR DESCRIPTION
As a small followup to #115