### PR TITLE
Remove tests against Django 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django-version: ['3.2', '4.2', '5.0', '5.1', 'main']
+        django-version: ['4.2', '5.0', '5.1', 'main']
         postgres-version: ['12', '16']
         mariadb-version: ['10.6', '10.11', '11.2']
         exclude:
-          # Django <=4.0 doesn't support python 3.11 (https://docs.djangoproject.com/en/4.1/faq/install/)
-          - python-version: '3.11'
-            django-version: '3.2'
-          - python-version: '3.12'
-            django-version: '3.2'
-
           # Django 5.0 doesn't support python <=3.9 (https://docs.djangoproject.com/en/5.0/faq/install/)
           - python-version: '3.8'
             django-version: '5.0'
@@ -43,12 +37,6 @@ jobs:
             django-version: 'main'
           - python-version: '3.9'
             django-version: 'main'
-
-          # only test Django dev with PostgreSQL 12 and MariaDB 10.4
-          - django-version: '3.2'
-            postgres-version: '12'
-          - django-version: '3.2'
-            mariadb-version: '10.4'
 
     services:
       postgres:

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
     4.2: dj42
     5.0: dj50
     5.1: dj51
@@ -16,7 +15,6 @@ DJANGO =
 
 [tox]
 envlist =
-    py{38,39,310}-dj32-{sqlite3,mysql,postgresql}
     py{38,39,310,311,312}-dj42-{sqlite3,mysql,postgresql}
     py{310,311,312}-dj{50,51,main}-{sqlite3,mysql,postgresql}
 
@@ -29,7 +27,6 @@ deps =
     -rrequirements.txt
     mysql: mysqlclient
     postgresql: psycopg2-binary
-    dj32: django>=3.2,<3.3
     dj42: django>=4.2,<4.3
     dj50: django>=5.0,<5.1
     dj51: django>=5.1,<5.2


### PR DESCRIPTION
Django 3.2 is end-of-life.  Remove testing against Django 3.2.

For #727 