### PR TITLE
Officially declare support for Django 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Silk is a live profiling and inspection tool for the Django framework. Silk inte
 
 Silk has been tested with:
 
-* Django: 3.2, 4.2, 5.0
+* Django: 3.2, 4.2, 5.0, 5.1
 * Python: 3.8, 3.9, 3.10, 3.11, 3.12
 
 ## Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,5 +57,5 @@ Features
 Requirements
 ------------
 
-* Django: 3.2, 4.2, 5.0
+* Django: 3.2, 4.2, 5.0, 5.1
 * Python: 3.8, 3.9, 3.10

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',


### PR DESCRIPTION
#732 started testing against Django 5.1.

Django-silk can now officially declare Django 5.1 as supported.

For #730 