### PR TITLE
Remove Django 3.2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django-version: ['3.2', '4.2', '5.0', '5.1', 'main']
+        django-version: ['4.2', '5.0', '5.1', 'main']
         postgres-version: ['12', '16']
         mariadb-version: ['10.6', '10.11', '11.2']
         exclude:
-          # Django <=4.0 doesn't support python 3.11 (https://docs.djangoproject.com/en/4.1/faq/install/)
-          - python-version: '3.11'
-            django-version: '3.2'
-          - python-version: '3.12'
-            django-version: '3.2'
-
           # Django 5.0 doesn't support python <=3.9 (https://docs.djangoproject.com/en/5.0/faq/install/)
           - python-version: '3.8'
             django-version: '5.0'
@@ -43,12 +37,6 @@ jobs:
             django-version: 'main'
           - python-version: '3.9'
             django-version: 'main'
-
-          # only test Django dev with PostgreSQL 12 and MariaDB 10.4
-          - django-version: '3.2'
-            postgres-version: '12'
-          - django-version: '3.2'
-            mariadb-version: '10.4'
 
     services:
       postgres:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
   rev: '1.20.0'
   hooks:
   - id: django-upgrade
-    args: [--target-version, '3.2']
+    args: [--target-version, '4.2']
 - repo: https://github.com/hhatto/autopep8
   rev: 'v2.3.1'
   hooks:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Silk is a live profiling and inspection tool for the Django framework. Silk inte
 
 Silk has been tested with:
 
-* Django: 3.2, 4.2, 5.0, 5.1
+* Django: 4.2, 5.0, 5.1
 * Python: 3.8, 3.9, 3.10, 3.11, 3.12
 
 ## Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,5 +57,5 @@ Features
 Requirements
 ------------
 
-* Django: 3.2, 4.2, 5.0, 5.1
+* Django: 4.2, 5.0, 5.1
 * Python: 3.8, 3.9, 3.10

--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -22,7 +22,6 @@ INSTALLED_APPS = (
 
 ROOT_URLCONF = 'project.urls'
 
-# Django 3.2+
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 MIDDLEWARE = [

--- a/project/tests/test_view_requests.py
+++ b/project/tests/test_view_requests.py
@@ -26,19 +26,6 @@ class TestRootViewDefaults(TestCase):
 
 
 class TestContext(TestCase):
-    def assertQuerySetEqual(self, *args, **kwargs):
-        """
-        A shim for QuerySetEqual to enable support for multiple versions of Django
-        TODO: delete this after support for Django 3.2 is dropped
-        Reference: https://docs.djangoproject.com/en/5.0/topics/testing/tools/#django.test.TransactionTestCase.assertQuerySetEqual
-        """
-        if hasattr(super(), 'assertQuerySetEqual'):
-            # Django > 3.2
-            super().assertQuerySetEqual(*args, **kwargs)
-        else:
-            # Django < 5.1
-            super().assertQuerysetEqual(*args, **kwargs)
-
     def test_default(self):
         request = Mock(spec_set=['GET', 'session'])
         request.session = {}

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
@@ -37,7 +36,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'Django>=3.2',
+        'Django>=4.2',
         'sqlparse',
         'autopep8',
         'gprof2dot>=2017.09.19',

--- a/silk/models.py
+++ b/silk/models.py
@@ -6,6 +6,8 @@ from uuid import uuid4
 
 import sqlparse
 from django.conf import settings
+from django.core.files.storage import storages
+from django.core.files.storage.handler import InvalidStorageError
 from django.db import models, transaction
 from django.db.models import (
     BooleanField,
@@ -27,19 +29,11 @@ from silk.config import SilkyConfig
 from silk.utils.profile_parser import parse_profile
 
 try:
-    # New in Django 4.2
-    from django.core.files.storage import storages
-    from django.core.files.storage.handler import InvalidStorageError
-    try:
-        silk_storage = storages['SILKY_STORAGE']
-    except InvalidStorageError:
-        from django.utils.module_loading import import_string
-        storage_class = SilkyConfig().SILKY_STORAGE_CLASS or settings.DEFAULT_FILE_STORAGE
-        silk_storage = import_string(storage_class)()
-except ImportError:
-    # Deprecated since Django 4.2, Removed in Django 5.1
-    from django.core.files.storage import get_storage_class
-    silk_storage = get_storage_class(SilkyConfig().SILKY_STORAGE_CLASS)()
+    silk_storage = storages['SILKY_STORAGE']
+except InvalidStorageError:
+    from django.utils.module_loading import import_string
+    storage_class = SilkyConfig().SILKY_STORAGE_CLASS or settings.DEFAULT_FILE_STORAGE
+    silk_storage = import_string(storage_class)()
 
 
 # Seperated out so can use in tests w/o models

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
     4.2: dj42
     5.0: dj50
     5.1: dj51
@@ -16,7 +15,6 @@ DJANGO =
 
 [tox]
 envlist =
-    py{38,39,310}-dj32-{sqlite3,mysql,postgresql}
     py{38,39,310,311,312}-dj42-{sqlite3,mysql,postgresql}
     py{310,311,312}-dj{50,51,main}-{sqlite3,mysql,postgresql}
 
@@ -29,7 +27,6 @@ deps =
     -rrequirements.txt
     mysql: mysqlclient
     postgresql: psycopg2-binary
-    dj32: django>=3.2,<3.3
     dj42: django>=4.2,<4.3
     dj50: django>=5.0,<5.1
     dj51: django>=5.1,<5.2


### PR DESCRIPTION
Depends on #728  , #729 

Fixes #727 

This PR removes all code related to Django 3.2.  Note that this breaks support for Django 3.2.