### PR TITLE
Update networkx to v3.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 coverage==7.6.1
 factory-boy==3.3.1
 freezegun==1.5.1
-networkx==2.6
+networkx==3.2.1
+pillow==11.0.0
 pydot==1.4.2
 pygments==2.18.0
 pytest-cov==5.0.0


### PR DESCRIPTION
This updates networkx to v3.2.1.  It resolves a backwards incompatibility from v2.6.3 where optional requirements stopped being required in networkx.  Adding pillow as a dependency resolves this issue and fixes tests.