### PR TITLE
fix: update Logger warn to warning in middleware file

### DIFF
--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -178,7 +178,7 @@ class SilkyMiddleware:
                     break
                 except (AttributeError, DatabaseError):
                     if attempts >= max_attempts:
-                        Logger.warn('Exhausted _process_response attempts; not processing request')
+                        Logger.warning('Exhausted _process_response attempts; not processing request')
                         break
                 attempts += 1
         return response


### PR DESCRIPTION
Change Logger `warn` to `warning` due to deprecation.