### PR TITLE
Avoid timeout caused by Request with large body

### DIFF
--- a/silk/views/request_detail.py
+++ b/silk/views/request_detail.py
@@ -26,21 +26,21 @@ class RequestView(View):
             'request': request
         }
 
-        if len(silk_request.raw_body<20000): # Don't do this for large request
+        if len(silk_request.raw_body < 20000):  # Don't do this for large request
             body = silk_request.raw_body
             try:
                 body = json.loads(body)  # Incase encoded as JSON
             except (ValueError, TypeError):
-                pass            
+                pass
             context['curl'] = curl_cmd(url=request.build_absolute_uri(silk_request.path),
-                             method=silk_request.method,
-                             query_params=query_params,
-                             body=body,
-                             content_type=silk_request.content_type),
+                                       method=silk_request.method,
+                                       query_params=query_params,
+                                       body=body,
+                                       content_type=silk_request.content_type),
             context['client'] = gen(path=silk_request.path,
-                          method=silk_request.method,
-                          query_params=query_params,
-                          data=body,
-                          content_type=silk_request.content_type),            
-        
+                                    method=silk_request.method,
+                                    query_params=query_params,
+                                    data=body,
+                                    content_type=silk_request.content_type),
+
         return render(request, 'silk/request.html', context)

--- a/silk/views/request_detail.py
+++ b/silk/views/request_detail.py
@@ -19,24 +19,28 @@ class RequestView(View):
         query_params = None
         if silk_request.query_params:
             query_params = json.loads(silk_request.query_params)
-        body = silk_request.raw_body
-        try:
-            body = json.loads(body)  # Incase encoded as JSON
-        except (ValueError, TypeError):
-            pass
+
         context = {
             'silk_request': silk_request,
-            'curl': curl_cmd(url=request.build_absolute_uri(silk_request.path),
+            'query_params': json.dumps(query_params, sort_keys=True, indent=4) if query_params else None,
+            'request': request
+        }
+
+        if len(silk_request.raw_body<20000): # Don't do this for large request
+            body = silk_request.raw_body
+            try:
+                body = json.loads(body)  # Incase encoded as JSON
+            except (ValueError, TypeError):
+                pass            
+            context['curl'] = curl_cmd(url=request.build_absolute_uri(silk_request.path),
                              method=silk_request.method,
                              query_params=query_params,
                              body=body,
                              content_type=silk_request.content_type),
-            'query_params': json.dumps(query_params, sort_keys=True, indent=4) if query_params else None,
-            'client': gen(path=silk_request.path,
+            context['client'] = gen(path=silk_request.path,
                           method=silk_request.method,
                           query_params=query_params,
                           data=body,
-                          content_type=silk_request.content_type),
-            'request': request
-        }
+                          content_type=silk_request.content_type),            
+        
         return render(request, 'silk/request.html', context)

--- a/silk/views/request_detail.py
+++ b/silk/views/request_detail.py
@@ -26,7 +26,7 @@ class RequestView(View):
             'request': request
         }
 
-        if len(silk_request.raw_body < 20000):  # Don't do this for large request
+        if len(silk_request.raw_body) < 20000:  # Don't do this for large request
             body = silk_request.raw_body
             try:
                 body = json.loads(body)  # Incase encoded as JSON


### PR DESCRIPTION
I am frequently facing timeout because of request with very large body,
These are caused by body processing in request details to generate curl and client commands that are not so essential in most cases (in particular when working with large request) 