### PR TITLE
Skip converting bytes to string before json loading

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -279,10 +279,6 @@ class ResponseModelFactory:
                         )
             if content and content_type in content_types_json:
                 # TODO: Perhaps theres a way to format the JSON without parsing it?
-                if not isinstance(content, str):
-                    # byte string is not compatible with json.loads(...)
-                    # and json.dumps(...) in python3
-                    content = content.decode()
                 try:
                     body = json.dumps(json.loads(content), sort_keys=True, indent=4
                                       , ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)


### PR DESCRIPTION
Python 3.6+ (all versions of python supported by django-silk) can run `json.loads` on strings or bytes according to https://docs.python.org/3/library/json.html#json.loads

There is therefore no reason to decode bytes to strings before passing to `json.loads`