### PR TITLE
Make autopep8 optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,11 @@ setup(
     install_requires=[
         'Django>=4.2',
         'sqlparse',
-        'autopep8',
         'gprof2dot>=2017.09.19',
     ],
+    extras_require={
+        'formatting': ['autopep8'],
+    },
     python_requires='>=3.9',
     setup_requires=['setuptools_scm'],
 )

--- a/silk/code_generation/django_test_client.py
+++ b/silk/code_generation/django_test_client.py
@@ -1,6 +1,9 @@
 from urllib.parse import urlencode
 
-import autopep8
+try:
+    import autopep8
+except ImportError:
+    autopep8 = None
 from django.template import Context, Template
 
 from silk.profiling.dynamic import is_str_typ
@@ -42,7 +45,13 @@ def gen(path, method=None, query_params=None, data=None, content_type=None):
             data = "'%s'" % data
         context['data'] = data
         context['query_params'] = query_params
-    return autopep8.fix_code(
-        t.render(Context(context, autoescape=False)),
-        options=autopep8.parse_args(['--aggressive', '']),
-    )
+    code = t.render(Context(context, autoescape=False))
+    if autopep8:
+        # autopep8 is not a hard requirement, so we check if it's available
+        # if autopep8 is available, we use it to format the code and do things
+        # like remove long lines and improve readability
+        code = autopep8.fix_code(
+            code,
+            options=autopep8.parse_args(['--aggressive', '']),
+        )
+    return code

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
     djmain: https://github.com/django/django/archive/main.tar.gz
     py312: setuptools
     py313: setuptools
+extras = formatting
 setenv =
     PYTHONPATH={toxinidir}:{toxinidir}
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Fixes #780 

Mark autopep8 as an optional dependency.  If the dependency is available, use it, otherwise return the code as is.