### PR TITLE
Drop support for Django 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        django-version: ['4.2', '5.0', '5.1', 'main']
+        django-version: ['4.2', '5.1', 'main']
         postgres-version: ['13', '17']
         mariadb-version: ['10.6', '10.11', '11.4']
         exclude:
-          # Django 5.0 doesn't support python <=3.9 (https://docs.djangoproject.com/en/5.0/faq/install/)
-          - python-version: '3.9'
-            django-version: '5.0'
-
           # Django 5.1 doesn't support python <=3.9 (https://docs.djangoproject.com/en/5.1/faq/install/)
           - python-version: '3.9'
             django-version: '5.1'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Silk is a live profiling and inspection tool for the Django framework. Silk inte
 
 Silk has been tested with:
 
-* Django: 4.2, 5.0, 5.1
+* Django: 4.2, 5.1
 * Python: 3.9, 3.10, 3.11, 3.12, 3.13
 
 ## Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,5 +57,5 @@ Features
 Requirements
 ------------
 
-* Django: 4.2, 5.0, 5.1
+* Django: 4.2, 5.1
 * Python: 3.9, 3.10, 3.11, 3.12, 3.13

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
-        'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ python =
 [gh-actions:env]
 DJANGO =
     4.2: dj42
-    5.0: dj50
     5.1: dj51
     main: djmain
 
@@ -28,7 +27,6 @@ deps =
     mysql: mysqlclient
     postgresql: psycopg2-binary
     dj42: django>=4.2,<4.3
-    dj50: django>=5.0,<5.1
     dj51: django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
     py312: setuptools


### PR DESCRIPTION
Django 5.0 dropped security support on April 2, 2025 making it EOL.

This PR drops django-silk support for Django 5.0.