### PR TITLE
Replace deprecated logger.warn with logger.warning

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -283,7 +283,7 @@ class ResponseModelFactory:
                     body = json.dumps(json.loads(content), sort_keys=True, indent=4
                                       , ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)
                 except (TypeError, ValueError):
-                    Logger.warn(
+                    Logger.warning(
                         'Response to request with pk %s has content type %s but was unable to parse it'
                         % (self.request.pk, content_type)
                     )


### PR DESCRIPTION
From https://docs.python.org/3/library/logging.html#logging.Logger.warning:

```
Note There is an obsolete method warn which is functionally identical to warning. As warn is deprecated, please do not use it - use warning instead.
```

Basically the same as #766