### PR TITLE
Improving SQL details navigation UX

### DIFF
--- a/silk/static/silk/js/pages/sql.js
+++ b/silk/static/silk/js/pages/sql.js
@@ -1,0 +1,17 @@
+$(document).ready(function () {
+  document.querySelectorAll(".data-row").forEach((rowElement) => {
+    let sqlDetailUrl = rowElement.dataset.sqlDetailUrl;
+    rowElement.addEventListener("mousedown", (e) => {
+      switch (e.button) {
+        case 0:
+          window.location = sqlDetailUrl;
+          break;
+        case 1:
+          window.open(sqlDetailUrl);
+          break;
+        default:
+          break;
+      }
+    });
+  });
+});

--- a/silk/templates/silk/sql.html
+++ b/silk/templates/silk/sql.html
@@ -4,12 +4,14 @@
 {% load silk_filters %}
 {% load static %}
 {% load silk_inclusion %}
+{% load silk_urls %}
 
 {% block pagetitle %}Silky - SQL - {{ silk_request.path }}{% endblock %}
 
 {% block js %}
   <script type="text/javascript" src="{% static 'silk/lib/sortable.js' %}"></script>
   {{ block.super }}
+  <script src="{% static 'silk/js/pages/sql.js' %}"></script>
 {% endblock %}
 
 {% block style %}
@@ -57,16 +59,8 @@
                     <th class="right-aligned">Execution Time (ms)</th>
                 </tr>
                 {% for sql_query in items %}
-                    <!-- TODO: Pretty grimy... -->
-                    <tr class="data-row" onclick="window.location=' \
-                       {% if profile and silk_request %}\
-                           {% url "silk:request_and_profile_sql_detail" silk_request.id profile.id sql_query.id %}\
-                       {% elif profile %}\
-                           {% url "silk:profile_sql_detail" profile.id sql_query.id %}\
-                       {% elif silk_request %}\
-                           {% url "silk:request_sql_detail" silk_request.id sql_query.id %}\
-                       {% endif %}\
-                        ';">
+                    {% sql_detail_url silk_request profile sql_query as detail_url %}
+                    <tr class="data-row" data-sql-detail-url="{{ detail_url }}">
                         <td class="left-aligned">+{{ sql_query.start_time_relative }}</td>
                         <td class="left-aligned">{{ sql_query.first_keywords }}</td>
                         <td class="left-aligned">{{ sql_query.tables_involved|join:", " }}</td>

--- a/silk/templatetags/silk_urls.py
+++ b/silk/templatetags/silk_urls.py
@@ -1,0 +1,17 @@
+from django.template import Library
+from django.urls import reverse
+
+register = Library()
+
+
+@register.simple_tag
+def sql_detail_url(silk_request, profile, sql_query):
+    if profile and silk_request:
+        return reverse(
+            "silk:request_and_profile_sql_detail",
+            args=[silk_request.id, profile.id, sql_query.id],
+        )
+    elif profile:
+        return reverse("silk:profile_sql_detail", args=[profile.id, sql_query.id])
+    elif silk_request:
+        return reverse("silk:request_sql_detail", args=[silk_request.id, sql_query.id])


### PR DESCRIPTION
### Summary
Small "quality of life" improvement for the navigation on the SQL page. This enables the user to open new tabs with their middle mouse click and keeps the previous behavior for the left click.

There is also another minor adjustment to move the logic for the sql detail url into a template tag, cleaning up a small part of the code and addressing a very old TODO comment.

### Context
When debugging a request with multiple queries, it’s frustrating not being able to open each SQL query in its own tab.

Currently, you must open a query, then navigate back each time. This is really inefficient for someone who uses this constantly.
