### PR TITLE
Fix egg name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can install from master using the following, but please be aware that the ve
 may not be working for all versions specified in [requirements](#requirements)
 
 ```bash
-pip install -e git+https://github.com/jazzband/django-silk.git#egg=django-silk
+pip install -e git+https://github.com/jazzband/django-silk.git#egg=django_silk
 ```
 
 ## Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -51,4 +51,4 @@ You can also install directly from the github repo but please note that this ver
 
 .. code-block:: bash
 
-	pip install -e git+https://github.com/jazzband/django-silk.git#egg=silk
+	pip install -e git+https://github.com/jazzband/django-silk.git#egg=django_silk


### PR DESCRIPTION
The egg for django-silk should be `django_silk`, not `silk` (which hasn't been the name of this package in years) nor `django-silk`, which [pip will stop converting to django_silk soon](https://github.com/pypa/pip/pull/11617).