### PR TITLE
Respect override_settings in SilkyConfig

### DIFF
--- a/project/tests/test_config_override.py
+++ b/project/tests/test_config_override.py
@@ -1,0 +1,9 @@
+from django.test import TestCase, override_settings
+
+from silk.config import SilkyConfig
+
+
+class TestOverrideSettings(TestCase):
+    def test_respects_override_settings(self):
+        with override_settings(SILKY_INTERCEPT_PERCENT=0):
+            self.assertEqual(SilkyConfig().SILKY_INTERCEPT_PERCENT, 0)

--- a/silk/config.py
+++ b/silk/config.py
@@ -39,11 +39,13 @@ class SilkyConfig(metaclass=Singleton):
 
     def _setup(self):
         from django.conf import settings
+        from django.core.signals import setting_changed
 
         options = {option: getattr(settings, option) for option in dir(settings) if option.startswith('SILKY')}
         self.attrs = copy(self.defaults)
         self.attrs['SILKY_PYTHON_PROFILER_RESULT_PATH'] = settings.MEDIA_ROOT
         self.attrs.update(options)
+        setting_changed.connect(self._on_setting_changed)
 
     def __init__(self):
         super().__init__()
@@ -54,3 +56,8 @@ class SilkyConfig(metaclass=Singleton):
 
     def __setattribute__(self, key, value):
         self.attrs[key] = value
+
+    def _on_setting_changed(self, sender, **kwargs):
+        setting = kwargs.get('setting')
+        if setting and setting.startswith('SILKY'):
+            self.attrs[setting] = kwargs.get('value')


### PR DESCRIPTION
I have a use-case to selectively disable silk when running unit tests by using [override_settings](https://docs.djangoproject.com/en/5.2/topics/testing/tools/#django.test.override_settings) - currently this isn't supported as the SilkyConfig is loaded only once.

This PR fixes the scenario by having SilkyConfig listen to [setting_changed](https://docs.djangoproject.com/en/5.2/ref/signals/#setting-changed) and update its config accordingly.
