### PR TITLE
fix: curl/client values not rendering in request_detail

### DIFF
--- a/silk/views/request_detail.py
+++ b/silk/views/request_detail.py
@@ -36,11 +36,11 @@ class RequestView(View):
                                        method=silk_request.method,
                                        query_params=query_params,
                                        body=body,
-                                       content_type=silk_request.content_type),
+                                       content_type=silk_request.content_type)
             context['client'] = gen(path=silk_request.path,
                                     method=silk_request.method,
                                     query_params=query_params,
                                     data=body,
-                                    content_type=silk_request.content_type),
+                                    content_type=silk_request.content_type)
 
         return render(request, 'silk/request.html', context)


### PR DESCRIPTION
This was a regression from https://github.com/jazzband/django-silk/commit/0a84caaec72ea5ff7739599a64467b1867cd2f2a / https://github.com/jazzband/django-silk/pull/768

This PR fixes a bug where the Curl and Django Test Client code sections were empty. The reason for the bug was that the variables were tuples instead of strings. When the template is rendered, the `curl.strip` method is called which expected a string.

The result of this change is the following:

<img width="1020" height="315" alt="image" src="https://github.com/user-attachments/assets/c8202f4b-d826-4fde-8cc4-17bbe16f1810" />

Prior to the change:

<img width="1017" height="279" alt="image" src="https://github.com/user-attachments/assets/d5ae4dfa-388f-4729-bf9a-edaaf467b313" />



