### PR TITLE
Fix #665 and #714, add cleanup in middleware

### DIFF
--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -164,6 +164,10 @@ class SilkyMiddleware:
         # is not taken in account
         if silk_request:
             silk_request.save()
+        # Clean up after ourselves for the next request:
+        if hasattr(SQLCompiler, '_execute_sql'):
+            SQLCompiler.execute_sql = SQLCompiler._execute_sql
+            delattr(SQLCompiler, '_execute_sql')
         Logger.debug('Process response done.')
 
     def process_response(self, request, response):


### PR DESCRIPTION
Fix #665 and fix #714 by adding try/except logic for the case where the SQL query params contain non-unicode binary data. The observed behavior with this fix is that queries involving such data will not render "explain" content in django-silk, which I think is an acceptable compromise for now versus trying to actually fix the logic here to correctly handle binary data.

I noticed as a side effect of the above bug that (with a long lived server process), django-silk's wrapped `execute_sql` function was being applied to requests that shouldn't be processed by django-silk (i.e. `_should_intercept()` returns False). This is because the wrapper wasn't being removed after processing a request, so all subsequent requests received by the process after any one `_should_intercept() == True` request were still getting the wrapper code. I've fixed this as well by adding appropriate logic in `process_response()` to revert the function wrapper when done with a request.