### PR TITLE
Update python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ networkx==3.2.1
 pillow==11.3.0
 pydot==3.0.4
 pygments==2.19.2
-pytest-cov==6.1.1
+pytest-cov==6.2.1
 pytest-django==4.11.1


### PR DESCRIPTION
Update all updateable python packages to latest.

Note: newer versions of `pydot` and `networkx` are available but not updated because of compatibility issues. 