### PR TITLE
Fix sql encoding error again

### DIFF
--- a/project/tests/test_execute_sql.py
+++ b/project/tests/test_execute_sql.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, NonCallableMagicMock, NonCallableMock, patch
 
 from django.test import TestCase
+from django.utils.encoding import force_str
 
 from silk.collector import DataCollector
 from silk.models import Request, SQLQuery
@@ -14,8 +15,9 @@ def mock_sql():
     mock_sql_query._execute_sql = Mock()
     mock_sql_query.query = NonCallableMock(spec_set=['model'])
     mock_sql_query.query.model = Mock()
-    query_string = 'SELECT * from table_name'
-    mock_sql_query.as_sql = Mock(return_value=(query_string, ()))
+    query_string = 'SELECT * FROM table_name WHERE column1 = %s AND column2 = %s'
+    params = (b'\x0a\x00\x00\xff', 1)
+    mock_sql_query.as_sql = Mock(return_value=(query_string, params))
 
     mock_sql_query.connection = NonCallableMock(
         spec_set=['cursor', 'features', 'ops'],
@@ -30,13 +32,13 @@ def mock_sql():
         ops=NonCallableMock(spec_set=['explain_query_prefix']),
     )
 
-    return mock_sql_query, query_string
+    return mock_sql_query, query_string, params
 
 
 def call_execute_sql(cls, request):
     DataCollector().configure(request=request)
     delete_all_models(SQLQuery)
-    cls.mock_sql, cls.query_string = mock_sql()
+    cls.mock_sql, cls.query_string, cls.params = mock_sql()
     kwargs = {
         'one': 1,
         'two': 2
@@ -79,7 +81,8 @@ class TestCallRequest(TestCase):
 
     def test_query(self):
         query = list(DataCollector().queries.values())[0]
-        self.assertEqual(query['query'], self.query_string)
+        expected = self.query_string % tuple(force_str(param, errors="backslashreplace") for param in self.params)
+        self.assertEqual(query['query'], expected)
 
 
 class TestCallSilky(TestCase):
@@ -88,7 +91,7 @@ class TestCallSilky(TestCase):
 
     def test_no_effect(self):
         DataCollector().configure()
-        sql, _ = mock_sql()
+        sql, _, _ = mock_sql()
         sql.query.model = NonCallableMagicMock(spec_set=['__module__'])
         sql.query.model.__module__ = 'silk.models'
         # No SQLQuery models should be created for silk requests for obvious reasons
@@ -110,23 +113,24 @@ class TestCollectorInteraction(TestCase):
 
     def test_request(self):
         DataCollector().configure(request=Request.objects.create(path='/path/to/somewhere'))
-        sql, _ = mock_sql()
+        sql, _, _ = mock_sql()
         execute_sql(sql)
         query = self._query()
         self.assertEqual(query['request'], DataCollector().request)
 
     def test_registration(self):
         DataCollector().configure(request=Request.objects.create(path='/path/to/somewhere'))
-        sql, _ = mock_sql()
+        sql, _, _ = mock_sql()
         execute_sql(sql)
         query = self._query()
         self.assertIn(query, DataCollector().queries.values())
 
     def test_explain(self):
         DataCollector().configure(request=Request.objects.create(path='/path/to/somewhere'))
-        sql, qs = mock_sql()
+        sql, qs, params = mock_sql()
         prefix = "EXPLAIN"
         mock_cursor = sql.connection.cursor.return_value.__enter__.return_value
         sql.connection.ops.explain_query_prefix.return_value = prefix
         execute_sql(sql)
-        mock_cursor.execute.assert_called_once_with(f"{prefix} {qs}", ())
+        expected = tuple(force_str(param, errors="backslashreplace") for param in params)
+        mock_cursor.execute.assert_called_once_with(f"{prefix} {qs}", expected)

--- a/silk/sql.py
+++ b/silk/sql.py
@@ -55,7 +55,8 @@ def _explain_query(connection, q, params):
         # for queries other than `select`
         prefixed_query = f"{prefix} {q}"
         with connection.cursor() as cur:
-            cur.execute(prefixed_query, params)
+            params_str = tuple(force_str(param, errors="backslashreplace") for param in params)
+            cur.execute(prefixed_query, params_str)
             result = _unpack_explanation(cur.fetchall())
             return '\n'.join(result)
     return None
@@ -77,7 +78,7 @@ def execute_sql(self, *args, **kwargs):
             return iter([])
         else:
             return
-    sql_query = q % tuple(force_str(param) for param in params)
+    sql_query = q % tuple(force_str(param, errors="backslashreplace") for param in params)
     if _should_wrap(sql_query):
         tb = ''.join(reversed(traceback.format_stack()))
         query_dict = {


### PR DESCRIPTION
This attempts to fix sql encoding errors again in `sql.py`.  There are two areas where sql encoding may be broken.  One is in `execute_sql` and another is in `_explain_query`.  This fix is for the former which is more critical because it's in the hot path.  If this doesn't fix the issue, it may be more practical to just wrap the entire `execute_sql` logic in a `try` statement with a `finally` that just calls the original Django logic.

When I looked into this further, I think a core issue is that django-silk is trying to store SQL in a TextField even though the params could be a non-text binary.  However, changing django-silk to use a BinaryField to store SQL would take some effort.

----

This is basically a redo of #658 from @bpascard, with him added as a coauthor.

This PR comes after #807 due to issues with JSONField compatibility as noted in #806 .

This is a long series of issues and pull requests including:
1. #658 which this pull request is based on
2. #617 which somewhat fixes issues
3. #665 
4. #714 
5. #570 
6. #315 
7. and many others that have been a constant pain for years: https://github.com/jazzband/django-silk/issues?q=is%3Aissue%20state%3Aclosed%20encoding

Depends on #807
TODO: rebase after #807 is merged.