### PR TITLE
Fix middleware cleanup race condition

### DIFF
--- a/project/tests/test_silky_middleware.py
+++ b/project/tests/test_silky_middleware.py
@@ -1,20 +1,20 @@
 from unittest.mock import patch
 
-from django.db.models.sql.compiler import SQLCompiler
-from django.http import HttpResponse
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from silk.config import SilkyConfig
 from silk.errors import SilkNotConfigured
-from silk.middleware import ORIGINAL_EXECUTE_SQL, SilkyMiddleware, _should_intercept
+from silk.middleware import SilkyMiddleware, _should_intercept
 from silk.models import Request
 
 from .util import mock_data_collector
 
 
-def fake_get_response(*args):
-    return HttpResponse('hello world')
+def fake_get_response():
+    def fake_response():
+        return 'hello world'
+    return fake_response
 
 
 class TestApplyDynamicMappings(TestCase):
@@ -115,28 +115,6 @@ class TestApplyDynamicMappings(TestCase):
                 "SILKY_AUTHENTICATION can not be enabled without Session, Authentication or Message Django's middlewares"
             ):
                 SilkyMiddleware(fake_get_response)
-
-
-class TestMiddleware(TestCase):
-    def test_wrapper_cleanup(self):
-        # Not yet decorated
-        self.assertIs(SQLCompiler.execute_sql, ORIGINAL_EXECUTE_SQL)
-
-        middleware = SilkyMiddleware(fake_get_response)
-
-        request = RequestFactory().get("/myapp/foo")
-        middleware(request)
-        self.assertTrue(request.silk_is_intercepted)
-
-        # Cleaned up
-        self.assertIs(SQLCompiler.execute_sql, ORIGINAL_EXECUTE_SQL)
-
-        request = RequestFactory().get(reverse('silk:summary'))
-        middleware(request)
-        self.assertFalse(getattr(request, "silk_is_intercepted", False))
-
-        # Cleaned up
-        self.assertIs(SQLCompiler.execute_sql, ORIGINAL_EXECUTE_SQL)
 
 
 class TestShouldIntercept(TestCase):

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -42,8 +42,6 @@ AUTH_AND_SESSION_MIDDLEWARES = [
     'django.contrib.messages.middleware.MessageMiddleware',
 ]
 
-ORIGINAL_EXECUTE_SQL = SQLCompiler.execute_sql
-
 
 def _should_intercept(request):
     """we want to avoid recording any requests/sql queries etc that belong to Silky"""
@@ -184,8 +182,4 @@ class SilkyMiddleware:
                         Logger.warning('Exhausted _process_response attempts; not processing request')
                         break
                 attempts += 1
-        # Clean up after ourselves for the next request:
-        if hasattr(SQLCompiler, '_execute_sql'):
-            SQLCompiler.execute_sql = ORIGINAL_EXECUTE_SQL
-            delattr(SQLCompiler, '_execute_sql')
         return response


### PR DESCRIPTION
I believe there is a race condition when adding/removing the `execute_sql` wrapper in multi-threaded environments which was added in #798 as a way for silk to clean up after itself.  This fully reverts #798 (other parts of it were reverted in #807) to remove the race condition.

Fixes #811 
Reverts #798 
