### PR TITLE
Adapt _process_response for runtime database selection

### DIFF
--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -143,29 +143,29 @@ class SilkyMiddleware:
         request_model = RequestModelFactory(request).construct_request_model()
         DataCollector().configure(request_model, should_profile=should_profile)
 
-    @transaction.atomic(using=router.db_for_write(models.SQLQuery))
     def _process_response(self, request, response):
-        Logger.debug('Process response')
-        with silk_meta_profiler():
-            collector = DataCollector()
-            collector.stop_python_profiler()
-            silk_request = collector.request
+        with transaction.atomic(using=router.db_for_write(models.SQLQuery)):
+            Logger.debug('Process response')
+            with silk_meta_profiler():
+                collector = DataCollector()
+                collector.stop_python_profiler()
+                silk_request = collector.request
+                if silk_request:
+                    ResponseModelFactory(response).construct_response_model()
+                    silk_request.end_time = timezone.now()
+                    collector.finalise()
+                else:
+                    Logger.error(
+                        'No request model was available when processing response. '
+                        'Did something go wrong in process_request/process_view?'
+                        '\n' + str(request) + '\n\n' + str(response)
+                    )
+            # Need to save the data outside the silk_meta_profiler
+            # Otherwise the  meta time collected in the context manager
+            # is not taken in account
             if silk_request:
-                ResponseModelFactory(response).construct_response_model()
-                silk_request.end_time = timezone.now()
-                collector.finalise()
-            else:
-                Logger.error(
-                    'No request model was available when processing response. '
-                    'Did something go wrong in process_request/process_view?'
-                    '\n' + str(request) + '\n\n' + str(response)
-                )
-        # Need to save the data outside the silk_meta_profiler
-        # Otherwise the  meta time collected in the context manager
-        # is not taken in account
-        if silk_request:
-            silk_request.save()
-        Logger.debug('Process response done.')
+                silk_request.save()
+            Logger.debug('Process response done.')
 
     def process_response(self, request, response):
         max_attempts = 2


### PR DESCRIPTION
Previously, _process_response used a @transaction.atomic decorator, which evaluated the database at import time. Since the database can change at runtime, this caused connection errors in certain scenarios (in my case, multitenant server that uses request host to identify database).

This PR updates _process_response to:

Use a runtime-evaluated database alias inside a with transaction.atomic(using=...) block.

Impact:

Fixes runtime database connection issues.

Ensures profiling and response processing continue to work as intended.