### PR TITLE
Fix mouse event for sql details navigation

### DIFF
--- a/silk/static/silk/js/pages/sql.js
+++ b/silk/static/silk/js/pages/sql.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
   document.querySelectorAll(".data-row").forEach((rowElement) => {
     let sqlDetailUrl = rowElement.dataset.sqlDetailUrl;
-    rowElement.addEventListener("click", (e) => {
+    rowElement.addEventListener("mouseup", (e) => {
       switch (e.button) {
         case 0:
           window.location = sqlDetailUrl;


### PR DESCRIPTION
As a followup to https://github.com/jazzband/django-silk/pull/788#discussion_r2627321603, fix the event listener to also trigger on middle clicks.

@joaopedroalbq
