### PR TITLE
Fix test coverage issue

### DIFF
--- a/silk/collector.py
+++ b/silk/collector.py
@@ -95,7 +95,7 @@ class DataCollector(metaclass=Singleton):
             self.local.pythonprofiler = cProfile.Profile()
             try:
                 self.local.pythonprofiler.enable()
-            except ValueError as e:
+            except ValueError as e:  # pragma: no cover
                 # Deal with cProfile not being allowed to run concurrently
                 # https://github.com/jazzband/django-silk/issues/682
                 Logger.error('Could not enable python profiler, %s' % str(e), exc_info=True)


### PR DESCRIPTION
This branch is sometimes covered or not covered by tests depending on a race condition of whether cProfile is running concurrently.  This should ignore the `except` so that test coverage doesn't vary on race conditions.