### PR TITLE
update javascript mime type from text/javascript to application/javascript

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -17,7 +17,7 @@ Logger = logging.getLogger('silk.model_factory')
 
 content_types_json = ['application/json',
                       'application/x-javascript',
-                      'text/javascript',
+                      'application/javascript',
                       'text/x-javascript',
                       'text/x-json']
 multipart_form = 'multipart/form-data'


### PR DESCRIPTION
### Problem

The `django-silk` library is logging an exception in uwsgi because it expects JavaScript responses to have the deprecated `text/javascript` content type. Modern web standards and many clients/servers (like uwsgi in this case) correctly use `application/javascript`. This mismatch causes unnecessary exceptions to be logged, potentially obscuring more critical issues and indicating a deviation from current best practices.

### Changes

Locate the string `"text/javascript"` within `silk/model_factory.py` that is used for content type comparison or assignment related to JavaScript responses, and change it to `"application/javascript"`. This will align the library with current MIME type standards for JavaScript.

**Modified files:**
- `silk/model_factory.py` (modified)

---
Tested by running the project's existing test suite. No unrelated changes included.


Closes #374