### PR TITLE
Fix finalise() TypeError on retry when 'model' key present in query dict

### DIFF
--- a/project/tests/test_collector.py
+++ b/project/tests/test_collector.py
@@ -3,6 +3,7 @@ import os.path
 import sys
 
 from django.test import TestCase
+from django.utils import timezone
 from tests.util import DictStorage
 
 from silk.collector import DataCollector
@@ -50,6 +51,21 @@ class TestCollector(TestCase):
                 content = f.read()
                 self.assertTrue(content)
                 self.assertGreater(len(content), 0)
+
+    def test_finalise_is_idempotent(self):
+        request = RequestMinFactory()
+        DataCollector().configure(request, should_profile=False)
+        DataCollector().register_query({
+            'query': 'SELECT 1',
+            'start_time': timezone.now(),
+            'end_time': timezone.now(),
+            'traceback': '',
+            'analysis': None,
+            'request': request,
+        })
+        DataCollector().finalise()
+        # Second call must not raise TypeError from stale 'model' key in query dict
+        DataCollector().finalise()
 
     def test_configure_exception(self):
         other_profiler = cProfile.Profile()

--- a/silk/collector.py
+++ b/silk/collector.py
@@ -161,7 +161,7 @@ class DataCollector(metaclass=Singleton):
         sql_queries = []
         for identifier, query in self.queries.items():
             query['identifier'] = identifier
-            sql_query = models.SQLQuery(**query)
+            sql_query = models.SQLQuery(**{k: v for k, v in query.items() if k != 'model'})
             sql_queries += [sql_query]
 
         models.SQLQuery.objects.bulk_create(sql_queries)


### PR DESCRIPTION
## Summary

Closes #867

`DataCollector.finalise()` mutates each query dict by writing back a `model` key (a `SQLQuery` instance) after `bulk_create`, so that the profile-linking block below can correlate profiles with their DB rows. The `SilkyMiddleware.process_response` retry loop can call `finalise()` a second time if the first `_process_response` raises `AttributeError` or `DatabaseError`. On the second call, `models.SQLQuery(**query)` receives the stale `model` key and Django raises:

      TypeError: SQLQuery() got unexpected keyword arguments: 'model'

This `TypeError` is not caught by the `except (AttributeError, DatabaseError)` clause, so it propagates as an unrelated 500.

## Fix

Exclude the `model` key when constructing the `SQLQuery` instance. The `model` reference is written back into the dict afterwards (unchanged) and remains available for profile-query linking on the first call.

## Test

`test_finalise_is_idempotent` configures a collector with a query, calls `finalise()` twice, and asserts no `TypeError` is raised on the second call.