### PR TITLE
Exclude NULL view_names from the View filter dropdown

### DIFF
--- a/project/tests/test_view_requests.py
+++ b/project/tests/test_view_requests.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from silk.middleware import silky_reverse
 from silk.views.requests import RequestsView
 
+from .factories import RequestMinFactory
 from .test_lib.assertion import dict_contains
 from .test_lib.mock_suite import MockSuite
 
@@ -23,6 +24,15 @@ class TestRootViewDefaults(TestCase):
 
     def test_order_by(self):
         self.assertIn(RequestsView.default_order_by, RequestsView.order_by)
+
+    def test_get_views_excludes_blank_and_null_view_names(self):
+        RequestMinFactory(view_name=None)
+        RequestMinFactory(view_name='')
+        RequestMinFactory(view_name='myapp.views.index')
+        view_names = list(RequestsView()._get_views())
+        self.assertNotIn(None, view_names)
+        self.assertNotIn('', view_names)
+        self.assertIn('myapp.views.index', view_names)
 
 
 class TestContext(TestCase):

--- a/silk/views/requests.py
+++ b/silk/views/requests.py
@@ -1,4 +1,4 @@
-from django.db.models import Sum
+from django.db.models import Q, Sum
 from django.shortcuts import render
 from django.template.context_processors import csrf
 from django.utils.decorators import method_decorator
@@ -86,7 +86,7 @@ class RequestsView(View):
             'view_name',
             flat=True
         ).exclude(
-            view_name=''
+            Q(view_name='') | Q(view_name__isnull=True)
         ).order_by(
             'view_name'
         ).distinct()


### PR DESCRIPTION
Closes #830

`Request.view_name` allows NULL, so requests without a matched view have `view_name=NULL` in the database. `_get_views()` excluded empty strings but not NULLs, so NULL appeared as the string "None" in the View filter dropdown — and because it rendered before the blank option, it defaulted
to selected.

Applying the View filter with value `"None"` calls `ViewNameFilter('None')`, which issues `WHERE view_name = 'None'` (matching no rows). This made the path, method, and milliseconds filters appear to return zero results whenever the View dropdown was left at its default.