### PR TITLE
Fix AttributeError generating curl command for non-string query params

### DIFF
--- a/project/tests/test_code_gen_curl.py
+++ b/project/tests/test_code_gen_curl.py
@@ -39,4 +39,3 @@ class TestCodeGenCurl(TestCase):
         )
 
         self.assertIn("log_time=1543406262.021423", result)
-

--- a/project/tests/test_code_gen_curl.py
+++ b/project/tests/test_code_gen_curl.py
@@ -21,3 +21,22 @@ class TestCodeGenCurl(TestCase):
             '-d', '{"gamma": "delta"}',
             'https://example.org/alpha/beta'
         ])
+
+    def test_non_string_query_param_value(self):
+        """
+        Regression test for
+        https://github.com/jazzband/django-silk/issues/317
+
+        A non-string query param value (e.g. a float, as in the
+        issue's reproduction) must not raise AttributeError when
+        generating the curl command.
+        """
+        result = curl_cmd(
+            url="https://example.org/alpha/beta",
+            method="GET",
+            query_params={"log_time": 1543406262.021423},
+            content_type="application/json",
+        )
+
+        self.assertIn("log_time=1543406262.021423", result)
+

--- a/silk/code_generation/curl.py
+++ b/silk/code_generation/curl.py
@@ -17,7 +17,7 @@ def _curl_process_params(body, content_type, query_params):
     if query_params:
         try:
             query_params = urlencode(
-                [(k, v.encode('utf8')) for k, v in query_params.items()]
+                [(k, str(v).encode('utf8')) for k, v in query_params.items()]
             )
         except TypeError:
             pass


### PR DESCRIPTION
Fixes #317.

`_curl_process_params()` called `v.encode('utf8')` directly on every query param value. This assumes every value is already a string; a non-string value (most commonly a float, e.g. a timestamp like `1543406262.021423`, as in the issue) has no `.encode()` method and raises `AttributeError`, breaking the "view as curl" feature entirely for any request with a non-string query param.

The existing `except TypeError` around this block doesn't help here, since calling a nonexistent method raises `AttributeError`, not `TypeError` -- a different exception than what's actually being guarded against.

**Fix**: convert each value to `str` before encoding, matching the same approach already used a few lines below for the request body (`body = str(body)`), so any value type is handled uniformly -- exactly matching the reporter's own tested fix.

**Testing**: verified against the exact reproduction from the issue (a float-valued query param). Confirmed the fix resolves it while producing the correct URL-encoded output, and confirmed normal string values and a mix of string/int/float/bool values all continue to work correctly.

Added a regression test using the project's existing `curl_cmd` integration-test style. I confirmed the test fails with the original code (raises `AttributeError`) and passes with the fix. Ran the existing `test_code_gen_curl.py` suite (2 passed: 1 baseline + 1 new) and the broader project test suite; the only failure and the many errors present are pre-existing and unrelated to this change (a pre-existing whitespace-formatting mismatch in an unrelated Django code-gen test, and numerous tests requiring a live PostgreSQL connection not available in my sandbox) -- confirmed identical on a clean checkout of `master`.
