### PR TITLE
Fix delete_model() using a hardcoded batch size that can exceed SQLite's actual variable limit

### DIFF
--- a/project/tests/test_data_deletion.py
+++ b/project/tests/test_data_deletion.py
@@ -1,0 +1,70 @@
+from unittest import mock
+
+from django.db import connection, connections
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from silk.models import Request
+from silk.utils.data_deletion import delete_model
+
+from .factories import RequestMinFactory, ResponseFactory
+
+
+class TestDeleteModel(TestCase):
+    def test_delete_model_removes_all_rows(self):
+        for _ in range(5):
+            RequestMinFactory.create()
+        self.assertEqual(Request.objects.count(), 5)
+
+        delete_model(Request)
+
+        self.assertEqual(Request.objects.count(), 0)
+
+    def test_delete_model_respects_constrained_max_query_params(self):
+        """
+        Regression test for
+        https://github.com/jazzband/django-silk/issues/421
+
+        delete_model() previously used a hardcoded batch size (800)
+        regardless of the database backend's actual query parameter
+        limit. That limit varies across SQLite builds/versions (and is
+        exposed to Django as connection.features.max_query_params), so
+        a hardcoded batch size that happens to work in one environment
+        can still exceed a more constrained build's real limit
+        elsewhere, raising "too many SQL variables". Every DELETE
+        statement issued -- including cascade deletes on related
+        tables -- must never use more parameters than the backend's
+        actual limit allows.
+        """
+        for _ in range(30):
+            ResponseFactory.create()
+        self.assertEqual(Request.objects.count(), 30)
+
+        with mock.patch.object(
+            connections["default"].features.__class__,
+            "max_query_params",
+            5,
+        ):
+            with CaptureQueriesContext(connection) as ctx:
+                delete_model(Request)
+
+        self.assertEqual(Request.objects.count(), 0)
+
+        max_params_seen = 0
+        for query in ctx.captured_queries:
+            sql = query["sql"]
+            if "DELETE" not in sql.upper():
+                continue
+            start = sql.find("IN (")
+            if start == -1:
+                continue
+            end = sql.find(")", start)
+            param_count = sql[start + 4:end].count(",") + 1
+            max_params_seen = max(max_params_seen, param_count)
+
+        self.assertLessEqual(
+            max_params_seen,
+            5,
+            "a DELETE query used more parameters than the constrained "
+            "max_query_params limit allows",
+        )

--- a/silk/utils/data_deletion.py
+++ b/silk/utils/data_deletion.py
@@ -20,9 +20,21 @@ def delete_model(model):
 
     # Manually delete rows because sqlite does not support TRUNCATE and
     # oracle doesn't provide good support for disabling foreign key checks
+    #
+    # Batch size must not exceed the database's actual query parameter
+    # limit (e.g. SQLite's SQLITE_MAX_VARIABLE_NUMBER, exposed here as
+    # max_query_params). This varies across SQLite builds/versions --
+    # a previously hardcoded batch size that happened to work in one
+    # environment could still exceed a more constrained build's real
+    # limit elsewhere, causing "too many SQL variables". Capping at a
+    # reasonable default (800) keeps batches efficient when the
+    # backend's limit is high, while never exceeding it when the
+    # limit is lower. See GH #421.
+    max_query_params = connections[model.objects.db].features.max_query_params
+    batch_size = min(800, max_query_params) if max_query_params else 800
     while True:
         items_to_delete = list(
-            model.objects.values_list('pk', flat=True).all()[:800])
+            model.objects.values_list('pk', flat=True).all()[:batch_size])
         if not items_to_delete:
             break
         model.objects.filter(pk__in=items_to_delete).delete()


### PR DESCRIPTION
Fixes #421.

`delete_model()`'s manual per-batch deletion loop (used for SQLite and Oracle, which don't support `TRUNCATE` the way this function needs) sliced `items_to_delete` to a hardcoded 800 rows per batch, regardless of the database backend's actual query parameter limit.

SQLite's variable limit (`SQLITE_MAX_VARIABLE_NUMBER`) varies across builds and versions -- it isn't universally >= 800. A batch size that happens to work against one SQLite build can still exceed a more constrained build's real limit elsewhere, raising "too many SQL variables" exactly as in the issue. Since Django's cascade-delete collector also issues DELETE/SELECT queries against related tables using the same id list (e.g. deleting `Request` cascades to `Response`, `SQLQuery`, `Profile`), every one of those queries needs to individually respect the real limit too, not just the initial `pk__in` query.

**Fix**: use `connections[db].features.max_query_params` -- the same mechanism Django's own `bulk_batch_size()` uses internally for `bulk_create`/`bulk_update` -- to compute a safe batch size, capping at the previous 800 default when the backend's limit is higher (or undefined, e.g. Oracle) so behavior/performance for already-working setups is unchanged.

**Testing**: verified with a real Django + django-silk setup, using `CaptureQueriesContext` to inspect the actual executed SQL: with `max_query_params` mocked down to a small value (simulating a constrained SQLite build), every DELETE query -- including cascade deletes on the related `Response` table -- now correctly respects that limit. I confirmed this fails with the original hardcoded-800 code (a DELETE query using far more than the constrained limit's worth of parameters, reproducing the reported failure mode) and passes with the fix.

Added a regression test file (`test_data_deletion.py`) covering both a normal deletion (confirms all rows are still removed) and the constrained-limit scenario described above by inspecting captured queries. I confirmed the constrained-limit test fails with the original code and passes with the fix. Ran the directly relevant existing tests (`test_view_clear_db.py`) together with the new tests: 4 passed, no regressions. Also ran the full project test suite with a fixed random seed, with and without this change: identical 10 failures/248 passes in both cases, confirming those are pre-existing, unrelated test-order-dependent flakiness in this suite (verified by installing a real PostgreSQL server in my sandbox to match the project's actual test settings).
