### PR TITLE
Fix FiltersManager.get() raising AttributeError without session support

### DIFF
--- a/project/tests/test_filters.py
+++ b/project/tests/test_filters.py
@@ -232,3 +232,39 @@ class TestProfileFilters(TestCase):
         filtered = query_set.filter(time_taken_filter)
         for f in filtered:
             self.assertGreaterEqual(f.time_taken, c)
+
+
+class TestFiltersManager(TestCase):
+    """
+    Regression tests for
+    https://github.com/jazzband/django-silk/issues/361
+    """
+
+    def test_get_without_session_or_prior_save_returns_empty_dict(self):
+        """
+        get() must never raise, even for a request that has neither a
+        .session attribute nor a previously-set .silk_filters
+        attribute (i.e. save() was never called for this request) --
+        matching the safe default already used by the session-based
+        branch.
+        """
+        from silk.request_filters import FiltersManager
+
+        class BareRequest:
+            pass
+
+        manager = FiltersManager("summary_filters")
+        result = manager.get(BareRequest())
+        self.assertEqual(result, {})
+
+    def test_save_then_get_without_session_round_trips(self):
+        from silk.request_filters import FiltersManager
+
+        class BareRequest:
+            pass
+
+        manager = FiltersManager("summary_filters")
+        request = BareRequest()
+        manager.save(request, {"show": "all"})
+        self.assertEqual(manager.get(request), {"show": "all"})
+

--- a/project/tests/test_filters.py
+++ b/project/tests/test_filters.py
@@ -267,4 +267,3 @@ class TestFiltersManager(TestCase):
         request = BareRequest()
         manager.save(request, {"show": "all"})
         self.assertEqual(manager.get(request), {"show": "all"})
-

--- a/silk/request_filters.py
+++ b/silk/request_filters.py
@@ -244,4 +244,9 @@ class FiltersManager:
     def get(self, request):
         if hasattr(request, 'session'):
             return request.session.get(self.key, {})
-        return request.silk_filters
+        # Mirror the session branch's safe default: get() should never
+        # raise, even when this is the first time save() has been
+        # called for this request (or session support isn't available
+        # at all), in which case silk_filters was never set. See
+        # GH #361.
+        return getattr(request, 'silk_filters', {})


### PR DESCRIPTION
Fixes #361.

`get()` falls back to `request.silk_filters` when the request has no `.session` attribute. That attribute is only ever set by `save()` on the same request object, so for a request being processed for the first time (or when session support isn't available at all), it doesn't exist yet, and `get()` raises `AttributeError` instead of returning a default -- unlike the session-based branch just above it, which already safely defaults to `{}` via `request.session.get(self.key, {})`.

This breaks the summary/requests views' filter handling (e.g. context-building code that unconditionally does `raw_filters.pop(...)` and `raw_filters.items()` on the result), matching the reported symptom.

**Fix**: use `getattr(request, 'silk_filters', {})` so `get()` honors the same "always returns a dict, never raises" contract already established by the session branch.

**Testing**: verified directly: constructing a bare object with neither `.session` nor `.silk_filters` and calling `FiltersManager.get()` on it reproduces the exact `AttributeError` with the original code, and returns `{}` correctly with the fix. Confirmed `save()` then `get()` on the same session-less request still round-trips correctly, and that the existing session-based path is completely unaffected.

Added regression tests covering both cases. I confirmed the "no session, no prior save" test fails with the original code and passes with the fix. Ran the full existing `test_filters.py` suite (19 passed: 17 baseline + 2 new) and the summary view tests (2 passed), no regressions.
