### PR TITLE
Fix SILKY_IGNORE_PATHS matching when used with a SCRIPT_NAME prefix

### DIFF
--- a/project/tests/test_silky_middleware.py
+++ b/project/tests/test_silky_middleware.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
-from django.urls import reverse
+from django.urls import reverse, set_script_prefix
 
 from silk.config import SilkyConfig
 from silk.errors import SilkNotConfigured
@@ -152,15 +152,18 @@ class TestShouldIntercept(TestCase):
 
         self.assertFalse(should_intercept)
 
-    def test_should_intercept_uses_path_info_not_path(self):
+    def test_should_intercept_ignore_paths_behind_script_name_prefix(self):
         """
         Regression test for
         https://github.com/jazzband/django-silk/issues/349
 
-        Matching must be based on path_info (SCRIPT_NAME-stripped),
-        not path, so a front-end web server prefix doesn't cause
-        silk's own requests or a configured SILKY_IGNORE_PATHS entry
-        to go unrecognized.
+        A SILKY_IGNORE_PATHS entry is a plain string the user writes
+        in settings.py -- never passed through reverse() -- so it's
+        naturally written without any deployment-specific SCRIPT_NAME
+        prefix. Matching it must therefore use path_info (which has
+        that prefix stripped), not path (which still has it), or a
+        front-end web server prefix causes the entry to go
+        unrecognized.
         """
         SilkyConfig().SILKY_IGNORE_PATHS = [
             '/ignorethis'
@@ -175,10 +178,26 @@ class TestShouldIntercept(TestCase):
 
         self.assertFalse(should_intercept)
 
-        # Same idea for silk's own summary page.
-        request2 = Request()
-        request2.path = '/some-prefix' + reverse('silk:summary')
-        request2.path_info = reverse('silk:summary')
-        should_intercept2 = _should_intercept(request2)
+    def test_should_intercept_silk_request_behind_script_name_prefix(self):
+        """
+        Companion regression test for
+        https://github.com/jazzband/django-silk/issues/349.
 
-        self.assertFalse(should_intercept2)
+        Unlike SILKY_IGNORE_PATHS entries, get_fpath() is built from
+        reverse(), which picks up Django's script prefix (set from
+        SCRIPT_NAME by the WSGI handler on every real request) just
+        like request.path does. So when deployed behind a front-end
+        prefix, both request.path and reverse() include it together
+        and self-detection must keep comparing against request.path,
+        not the prefix-stripped request.path_info.
+        """
+        set_script_prefix('/some-prefix/')
+        try:
+            request = Request()
+            request.path = reverse('silk:summary')
+            request.path_info = reverse('silk:summary')[len('/some-prefix'):]
+            should_intercept = _should_intercept(request)
+
+            self.assertFalse(should_intercept)
+        finally:
+            set_script_prefix('/')

--- a/project/tests/test_silky_middleware.py
+++ b/project/tests/test_silky_middleware.py
@@ -121,6 +121,7 @@ class TestShouldIntercept(TestCase):
     def test_should_intercept_non_silk_request(self):
         request = Request()
         request.path = '/myapp/foo'
+        request.path_info = '/myapp/foo'
         should_intercept = _should_intercept(request)
 
         self.assertTrue(should_intercept)
@@ -128,6 +129,7 @@ class TestShouldIntercept(TestCase):
     def test_should_intercept_silk_request(self):
         request = Request()
         request.path = reverse('silk:summary')
+        request.path_info = reverse('silk:summary')
         should_intercept = _should_intercept(request)
 
         self.assertFalse(should_intercept)
@@ -136,6 +138,7 @@ class TestShouldIntercept(TestCase):
     def test_should_intercept_without_silk_urls(self):
         request = Request()
         request.path = '/login'
+        request.path_info = '/login'
         _should_intercept(request)  # Just checking no crash
 
     def test_should_intercept_ignore_paths(self):
@@ -144,6 +147,38 @@ class TestShouldIntercept(TestCase):
         ]
         request = Request()
         request.path = '/ignorethis'
+        request.path_info = '/ignorethis'
         should_intercept = _should_intercept(request)
 
         self.assertFalse(should_intercept)
+
+    def test_should_intercept_uses_path_info_not_path(self):
+        """
+        Regression test for
+        https://github.com/jazzband/django-silk/issues/349
+
+        Matching must be based on path_info (SCRIPT_NAME-stripped),
+        not path, so a front-end web server prefix doesn't cause
+        silk's own requests or a configured SILKY_IGNORE_PATHS entry
+        to go unrecognized.
+        """
+        SilkyConfig().SILKY_IGNORE_PATHS = [
+            '/ignorethis'
+        ]
+
+        # A path with a SCRIPT_NAME-style prefix that only path_info
+        # (not path) has stripped off.
+        request = Request()
+        request.path = '/some-prefix/ignorethis'
+        request.path_info = '/ignorethis'
+        should_intercept = _should_intercept(request)
+
+        self.assertFalse(should_intercept)
+
+        # Same idea for silk's own summary page.
+        request2 = Request()
+        request2.path = '/some-prefix' + reverse('silk:summary')
+        request2.path_info = reverse('silk:summary')
+        should_intercept2 = _should_intercept(request2)
+
+        self.assertFalse(should_intercept2)

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -55,11 +55,20 @@ def _should_intercept(request):
             return False
 
     try:
-        silky = request.path.startswith(get_fpath())
+        # Use path_info (not path) so this comparison is unaffected by
+        # any SCRIPT_NAME prefix a front-end web server may add ahead
+        # of the path Django itself sees -- get_fpath() (via reverse())
+        # returns a path without that prefix, so comparing against
+        # request.path here could incorrectly fail to recognize silk's
+        # own requests when deployed behind such a prefix. See GH #349.
+        silky = request.path_info.startswith(get_fpath())
     except NoReverseMatch:
         silky = False
 
-    ignored = request.path in config.SILKY_IGNORE_PATHS
+    # Likewise, use path_info here so a configured SILKY_IGNORE_PATHS
+    # entry (naturally written without any deployment-specific
+    # SCRIPT_NAME prefix) can still match correctly.
+    ignored = request.path_info in config.SILKY_IGNORE_PATHS
     return not (silky or ignored)
 
 

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -55,19 +55,21 @@ def _should_intercept(request):
             return False
 
     try:
-        # Use path_info (not path) so this comparison is unaffected by
-        # any SCRIPT_NAME prefix a front-end web server may add ahead
-        # of the path Django itself sees -- get_fpath() (via reverse())
-        # returns a path without that prefix, so comparing against
-        # request.path here could incorrectly fail to recognize silk's
-        # own requests when deployed behind such a prefix. See GH #349.
-        silky = request.path_info.startswith(get_fpath())
+        # get_fpath() (via reverse()) picks up Django's script prefix
+        # (set from SCRIPT_NAME by the WSGI handler on every real
+        # request), so it already includes any front-end web server
+        # prefix -- exactly like request.path does. Keep comparing
+        # against request.path here; request.path_info has that
+        # prefix stripped and would no longer match.
+        silky = request.path.startswith(get_fpath())
     except NoReverseMatch:
         silky = False
 
-    # Likewise, use path_info here so a configured SILKY_IGNORE_PATHS
-    # entry (naturally written without any deployment-specific
-    # SCRIPT_NAME prefix) can still match correctly.
+    # SILKY_IGNORE_PATHS entries are plain strings the user writes in
+    # settings.py -- never passed through reverse() -- so they're
+    # naturally written without any deployment-specific SCRIPT_NAME
+    # prefix. Use path_info (prefix-stripped) here so such an entry
+    # still matches when silk is deployed behind a prefix. See GH #349.
     ignored = request.path_info in config.SILKY_IGNORE_PATHS
     return not (silky or ignored)
 


### PR DESCRIPTION
`SILKY_IGNORE_PATHS` matching now uses `request.path_info` instead of `request.path`. `SILKY_IGNORE_PATHS` is a list of strings written in `settings.py` and not passed through `reverse()`, so they carry no `SCRIPT_NAME` prefix and must be matched against the prefix-stripped `path_info`.

Note: people may have worked around this bug by prefixing their `SILKY_IGNORE_PATHS` with a `SCRIPT_NAME` prefix.  After this is change is released, they will have to remove the prefixes from their `SILKY_IGNORE_PATHS`.

The below text was from the original pull request description:


Fixes #349.

`_should_intercept()` used `request.path` for both: (1) detecting whether a request is for silk's own UI (to avoid silk profiling itself), and (2) checking a configured `SILKY_IGNORE_PATHS` entry. `request.path` includes any SCRIPT_NAME prefix a front-end web server adds ahead of the path Django itself sees, while `get_fpath()` (via `reverse()`) and a user's `SILKY_IGNORE_PATHS` entries are naturally written without that deployment-specific prefix. When silk is deployed behind such a prefix, both checks can therefore fail to match paths they should, causing silk to profile its own UI requests and to ignore the SCRIPT_NAME-prefix mismatch for `SILKY_IGNORE_PATHS` entries -- matching the issue's report (which specifically called out the ignore-paths case, but the same root cause affects the silk-self-detection check too).

`request.path_info` is the SCRIPT_NAME-stripped equivalent -- the same convention Django's own URL resolver uses internally -- and is unaffected by front-end prefix configuration, exactly as the reporter suggested.

**Testing**: verified with a real Django request built via `RequestFactory` with an explicit `SCRIPT_NAME`, against a realistic urlconf with silk mounted under a sub-path (matching typical real-world usage, e.g. `path('silk/', include('silk.urls'))`): confirmed both checks (recognizing silk's own summary page and a configured ignore path) incorrectly failed to match with the original `request.path`-based code, and correctly match with the fix. Also confirmed the common case with no SCRIPT_NAME prefix at all is completely unaffected.

The existing test suite's `TestShouldIntercept` tests construct a bare `silk.models.Request` object (silk's own DB model, not a real `HttpRequest`) and manually set only `.path` on it as a stand-in. Since a real `HttpRequest` always has both `.path` and `.path_info` together, I updated these existing tests to also set `.path_info` (matching what a genuine request would have), and added a new regression test that exercises a `path`/`path_info` mismatch directly, matching the scenario a SCRIPT_NAME prefix produces.

Ran the full existing `test_silky_middleware.py` suite (13 passed: 12 baseline + 1 new). Confirmed the new regression test fails with the original `request.path`-based code and passes with the fix.
