### PR TITLE
Replace filter actions with native buttons

### DIFF
--- a/project/tests/test_filters.py
+++ b/project/tests/test_filters.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from itertools import groupby
 from math import floor
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.utils import timezone as django_timezone
 
 from silk import models
@@ -21,12 +21,27 @@ from silk.request_filters import (
     StatusCodeFilter,
     TimeSpentOnQueriesFilter,
     ViewNameFilter,
+    filters_from_request,
 )
 
 from .test_lib.mock_suite import MockSuite
 from .util import delete_all_models
 
 mock_suite = MockSuite()
+
+
+class TestFiltersFromRequest(TestCase):
+    def test_clear_filters_ignores_submitted_values(self):
+        request = RequestFactory().post(
+            '/',
+            {
+                'clear_filters': '1',
+                'filter-viewname-typ': 'ViewNameFilter',
+                'filter-viewname-value': 'view1',
+            },
+        )
+
+        self.assertEqual(filters_from_request(request), {})
 
 
 class TestRequestFilters(TestCase):

--- a/silk/request_filters.py
+++ b/silk/request_filters.py
@@ -208,6 +208,9 @@ class MethodFilter(BaseFilter):
 
 
 def filters_from_request(request):
+    if 'clear_filters' in request.POST:
+        return {}
+
     raw_filters = {}
     for key in request.POST:
         splt = key.split('-')

--- a/silk/static/silk/css/pages/root_base.css
+++ b/silk/static/silk/css/pages/root_base.css
@@ -150,6 +150,8 @@ input[type=text] {
   display: inline-block;
   background-color: white;
   color: black;
+  border: 0;
+  font: inherit;
   margin: 10px;
   padding: 10px;
   border-radius: 5px;

--- a/silk/static/silk/js/pages/root_base.js
+++ b/silk/static/silk/js/pages/root_base.js
@@ -6,10 +6,3 @@ function initFilterButton() {
         initFilters();
     });
 }
-function submitFilters() {
-    $('#filter-form2').submit();
-}
-function submitEmptyFilters() {
-    $('#cbp-spmenu-s2 :input:not([type=hidden])').val('');
-    submitFilters();
-}

--- a/silk/templates/silk/base/root_base.html
+++ b/silk/templates/silk/base/root_base.html
@@ -40,10 +40,10 @@
         </form>
 
         <div class="button-div">
-            <div class="apply-div" onclick="submitEmptyFilters()">Clear all filters</div>
+            <button class="apply-div" type="submit" form="filter-form2" name="clear_filters" value="1">Clear all filters</button>
         </div>
         <div class="button-div">
-            <div class="apply-div" onclick="submitFilters()">Apply</div>
+            <button class="apply-div" type="submit" form="filter-form2">Apply</button>
         </div>
 
     </nav>


### PR DESCRIPTION
Replace the filter action divs and JavaScript submit helpers with native submit buttons. Clear posts an explicit flag so it still empties saved filters, while the hidden default submit keeps Enter applying them.

Closes #615

Tests: `pytest project/tests/test_filters.py -q` (18 passed)
