### PR TITLE
Fix release/test build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel
+          python -m pip install -U build twine
 
       - name: Build package
         run: |
-          python setup.py --version
-          python setup.py sdist --format=gztar bdist_wheel
+          python -m build
+          ls -l dist/
           twine check dist/*
 
       - name: Upload packages to Jazzband

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/tox.ini') }}
+          ${{ matrix.python-version }}-v1-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
         restore-keys: |
           ${{ matrix.python-version }}-v1-
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+
 [tool.autopep8]
 ignore = "E501,E203,W503"
 in-place = true

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,4 @@ setup(
         'formatting': ['autopep8'],
     },
     python_requires='>=3.10',
-    setup_requires=['setuptools_scm'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,6 @@ deps =
     dj52: django>=5.2,<5.3
     dj60: django>=6.0,<6.1
     djmain: https://github.com/django/django/archive/main.tar.gz
-    py312: setuptools
-    py313: setuptools
-    py314: setuptools
 extras = formatting
 setenv =
     PYTHONPATH={toxinidir}:{toxinidir}


### PR DESCRIPTION
setuptools is getting outdated and broke on release.yml: https://github.com/jazzband/django-silk/actions/runs/31369230441/job/93394740518

This should remove the setuptools dependency for both test and release.  v5.5.1 will probably need to be re-released after this PR is merged.