### PR TITLE
fix: decompress gzip response bodies in raw view

### DIFF
--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -1,4 +1,7 @@
+import base64
 import datetime
+import gzip
+import json
 import uuid
 
 from django.core.management import call_command
@@ -235,6 +238,13 @@ class ResponseTest(TestCase):
 
         self.obj.encoded_headers = '{"content-type": "some_data"}'
         self.assertEqual(self.obj.content_type, "some_data")
+
+    def test_raw_body_decoded_decompresses_gzip_response(self):
+        content = b'hello from gzip'
+        self.obj.raw_body = base64.b64encode(gzip.compress(content)).decode('ascii')
+        self.obj.encoded_headers = json.dumps({'content-encoding': 'gzip'})
+
+        self.assertEqual(self.obj.raw_body_decoded, content)
 
 
 class SQLQueryManagerTest(TestCase):

--- a/silk/models.py
+++ b/silk/models.py
@@ -1,4 +1,5 @@
 import base64
+import gzip
 import json
 import random
 import re
@@ -221,7 +222,10 @@ class Response(models.Model):
 
     @property
     def raw_body_decoded(self):
-        return base64.b64decode(self.raw_body)
+        raw_body = base64.b64decode(self.raw_body)
+        if self.headers.get('content-encoding') == 'gzip':
+            return gzip.decompress(raw_body)
+        return raw_body
 
 
 # TODO rewrite docstring


### PR DESCRIPTION
Closes #845

Responses compressed by Django's `@gzip_page` decorator were stored with their `Content-Encoding: gzip` header, but Silk's raw response view only base64-decoded the payload and displayed binary gzip data. Decompress gzip-encoded payloads before displaying them while preserving existing behavior for other responses.

Tested with `DB_ENGINE=sqlite3 pytest project/tests/test_models.py`: 68 passed. The regression test fails without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
