### PR TITLE
Drop the settings.DEFAULT_FILE_STORAGE fallback removed in Django 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ When enabled, a graph visualisation generated using [gprof2dot](https://github.c
 A custom storage class can be used for the saved generated binary `.prof` files:
 
 ```python
-# For Django >= 4.2 and Django-Silk >= 5.1.0:
-# See https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-STORAGES
+# See https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-STORAGES
 STORAGES = {
     'SILKY_STORAGE': {
         'BACKEND': 'path.to.StorageClass',
@@ -196,7 +195,7 @@ STORAGES = {
     # ...
 }
 
-# For Django < 4.2 or Django-Silk < 5.1.0
+# Alternatively, if STORAGES has no 'SILKY_STORAGE' entry:
 SILKY_STORAGE_CLASS = 'path.to.StorageClass'
 ```
 

--- a/silk/models.py
+++ b/silk/models.py
@@ -5,7 +5,6 @@ import re
 from uuid import uuid4
 
 import sqlparse
-from django.conf import settings
 from django.core.files.storage import storages
 from django.core.files.storage.handler import InvalidStorageError
 from django.db import models, router, transaction
@@ -35,8 +34,7 @@ def get_silk_storage():
         return storages['SILKY_STORAGE']
     except InvalidStorageError:
         from django.utils.module_loading import import_string
-        storage_class = SilkyConfig().SILKY_STORAGE_CLASS or settings.DEFAULT_FILE_STORAGE
-        return import_string(storage_class)()
+        return import_string(SilkyConfig().SILKY_STORAGE_CLASS)()
 
 
 # Kept for historical migrations that reference silk.models.silk_storage.


### PR DESCRIPTION
`DEFAULT_FILE_STORAGE` is not supported anymore.  Stop checking it for configs.