### PR TITLE
Preserve in-flight requests when clearing silk logs

### DIFF
--- a/project/tests/test_command_clear_request_log.py
+++ b/project/tests/test_command_clear_request_log.py
@@ -1,0 +1,32 @@
+from django.core import management
+from django.test import TestCase
+from django.utils import timezone
+
+from silk import models
+
+from .factories import RequestMinFactory, ResponseFactory, SQLQueryFactory
+
+
+class TestClearRequestLogCommand(TestCase):
+    def test_clears_completed_requests(self):
+        completed = RequestMinFactory.create(end_time=timezone.now())
+        ResponseFactory.create(request=completed)
+        SQLQueryFactory.create(request=completed)
+
+        management.call_command("silk_clear_request_log")
+
+        self.assertEqual(models.Request.objects.count(), 0)
+        self.assertEqual(models.Response.objects.count(), 0)
+        self.assertEqual(models.SQLQuery.objects.count(), 0)
+
+    def test_preserves_in_flight_requests(self):
+        completed = RequestMinFactory.create(end_time=timezone.now())
+        ResponseFactory.create(request=completed)
+        in_flight = RequestMinFactory.create()
+        SQLQueryFactory.create(request=in_flight)
+
+        management.call_command("silk_clear_request_log")
+
+        self.assertFalse(models.Request.objects.filter(pk=completed.pk).exists())
+        self.assertTrue(models.Request.objects.filter(pk=in_flight.pk).exists())
+        self.assertEqual(models.SQLQuery.objects.filter(request=in_flight).count(), 1)

--- a/project/tests/test_command_garbage_collect.py
+++ b/project/tests/test_command_garbage_collect.py
@@ -1,5 +1,6 @@
 from django.core import management
 from django.test import TestCase
+from django.utils import timezone
 
 from silk import models
 from silk.config import SilkyConfig
@@ -7,10 +8,12 @@ from silk.config import SilkyConfig
 from .factories import RequestMinFactory
 
 
-class TestViewClearDB(TestCase):
+class TestGarbageCollectCommand(TestCase):
     def test_garbage_collect_command(self):
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 2
-        RequestMinFactory.create_batch(3)
+        now = timezone.now()
+        for _ in range(3):
+            RequestMinFactory.create(end_time=now)
         self.assertEqual(models.Request.objects.count(), 3)
         management.call_command("silk_request_garbage_collect")
         self.assertEqual(models.Request.objects.count(), 2)

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -114,6 +114,8 @@ class RequestTest(TestCase):
 
     def test_garbage_collect(self):
 
+        self.obj.end_time = self.obj.start_time
+        self.obj.save(update_fields=['end_time'])
         self.assertTrue(models.Request.objects.filter(id=self.obj.id).exists())
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 100
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 0
@@ -122,6 +124,8 @@ class RequestTest(TestCase):
 
     def test_probabilistic_garbage_collect(self):
 
+        self.obj.end_time = self.obj.start_time
+        self.obj.save(update_fields=['end_time'])
         self.assertTrue(models.Request.objects.filter(id=self.obj.id).exists())
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 0
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 0
@@ -130,6 +134,8 @@ class RequestTest(TestCase):
 
     def test_force_garbage_collect(self):
 
+        self.obj.end_time = self.obj.start_time
+        self.obj.save(update_fields=['end_time'])
         self.assertTrue(models.Request.objects.filter(id=self.obj.id).exists())
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 0
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 0
@@ -138,14 +144,27 @@ class RequestTest(TestCase):
 
     def test_greedy_garbage_collect(self):
 
+        self.obj.end_time = self.obj.start_time
+        self.obj.save(update_fields=['end_time'])
         for x in range(3):
-            obj = models.Request(path='/', method='get')
+            obj = models.Request(path='/', method='get', end_time=self.obj.start_time)
             obj.save()
         self.assertEqual(models.Request.objects.count(), 4)
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 50
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 3
         models.Request.garbage_collect(force=True)
         self.assertGreater(models.Request.objects.count(), 0)
+
+    def test_garbage_collect_preserves_in_flight_requests(self):
+
+        self.obj.end_time = self.obj.start_time
+        self.obj.save(update_fields=['end_time'])
+        in_flight = RequestMinFactory.create()
+        SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 100
+        SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 0
+        models.Request.garbage_collect(force=True)
+        self.assertFalse(models.Request.objects.filter(id=self.obj.id).exists())
+        self.assertTrue(models.Request.objects.filter(id=in_flight.id).exists())
 
     def test_save_if_have_no_raw_body(self):
 

--- a/project/tests/test_view_clear_db.py
+++ b/project/tests/test_view_clear_db.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.utils import timezone
 
 from silk import models
 from silk.config import SilkyConfig
@@ -15,11 +16,19 @@ class TestViewClearDB(TestCase):
         SilkyConfig().SILKY_AUTHORISATION = False
 
     def test_clear_all(self):
-        RequestMinFactory.create()
+        RequestMinFactory.create(end_time=timezone.now())
         self.assertEqual(models.Request.objects.count(), 1)
         response = self.client.post(silky_reverse("cleardb"), {"clear_all": "on"})
         self.assertTrue(response.status_code == 200)
         self.assertEqual(models.Request.objects.count(), 0)
+
+    def test_clear_preserves_in_flight_requests(self):
+        completed = RequestMinFactory.create(end_time=timezone.now())
+        in_flight = RequestMinFactory.create()
+        response = self.client.post(silky_reverse("cleardb"), {"clear_all": "on"})
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(models.Request.objects.filter(pk=completed.pk).exists())
+        self.assertTrue(models.Request.objects.filter(pk=in_flight.pk).exists())
 
 
 class TestViewClearDBAndDeleteProfiles(TestCase):
@@ -31,7 +40,7 @@ class TestViewClearDBAndDeleteProfiles(TestCase):
         SilkyConfig().SILKY_DELETE_PROFILES = True
 
     def test_clear_all_and_delete_profiles(self):
-        RequestMinFactory.create()
+        RequestMinFactory.create(end_time=timezone.now())
         self.assertEqual(models.Request.objects.count(), 1)
         response = self.client.post(silky_reverse("cleardb"), {"clear_all": "on"})
         self.assertTrue(response.status_code == 200)

--- a/silk/management/commands/silk_clear_request_log.py
+++ b/silk/management/commands/silk_clear_request_log.py
@@ -1,16 +1,12 @@
 from django.core.management.base import BaseCommand
 
-import silk.models
-from silk.utils.data_deletion import delete_model
+from silk.utils.data_deletion import clear_silk_data
 
 
 class Command(BaseCommand):
     help = "Clears silk's log of requests."
 
     def handle(self, *args, **options):
-        # Django takes a long time to traverse foreign key relations,
-        # so delete in the order that makes it easy.
-        delete_model(silk.models.Profile)
-        delete_model(silk.models.SQLQuery)
-        delete_model(silk.models.Response)
-        delete_model(silk.models.Request)
+        # Preserve in-flight requests (no end_time yet) so response
+        # finalization cannot hit IntegrityError on a deleted Request.
+        clear_silk_data()

--- a/silk/models.py
+++ b/silk/models.py
@@ -156,13 +156,16 @@ class Request(models.Model):
         if check_percent != 0:
             target_count -= int(1 / check_percent)
 
-        # Make sure we can delete everything if needed by settings
+        # Make sure we can delete everything if needed by settings.
+        # Skip in-flight requests (end_time unset) to avoid racing with
+        # response finalization, which would raise IntegrityError.
+        completed = cls.objects.exclude(end_time__isnull=True)
         if target_count <= 0:
-            cls.objects.all().delete()
+            completed.delete()
             return
 
         try:
-            time_cutoff = cls.objects.order_by(
+            time_cutoff = completed.order_by(
                 '-start_time'
             ).values_list(
                 'start_time',
@@ -171,7 +174,7 @@ class Request(models.Model):
         except IndexError:
             return
 
-        cls.objects.filter(start_time__lte=time_cutoff).delete()
+        completed.filter(start_time__lte=time_cutoff).delete()
 
     def save(self, *args, **kwargs):
         # sometimes django requests return the body as 'None'

--- a/silk/utils/data_deletion.py
+++ b/silk/utils/data_deletion.py
@@ -26,3 +26,29 @@ def delete_model(model):
         if not items_to_delete:
             break
         model.objects.filter(pk__in=items_to_delete).delete()
+
+
+def clear_silk_data():
+    """Delete silk request logs, preserving in-flight requests.
+
+    In-flight requests have ``end_time`` unset. Clearing them races with
+    response finalization and can raise IntegrityError when silk inserts a
+    Response for a Request that was just deleted.
+    """
+    # Imported lazily to avoid circular imports at module load.
+    from silk.models import Profile, Request, Response, SQLQuery
+
+    in_flight_ids = list(
+        Request.objects.filter(end_time__isnull=True).values_list('pk', flat=True)
+    )
+    if not in_flight_ids:
+        delete_model(Profile)
+        delete_model(SQLQuery)
+        delete_model(Response)
+        delete_model(Request)
+        return
+
+    Profile.objects.exclude(request_id__in=in_flight_ids).delete()
+    SQLQuery.objects.exclude(request_id__in=in_flight_ids).delete()
+    Response.objects.exclude(request_id__in=in_flight_ids).delete()
+    Request.objects.exclude(pk__in=in_flight_ids).delete()

--- a/silk/views/clear_db.py
+++ b/silk/views/clear_db.py
@@ -8,8 +8,7 @@ from django.views.generic import View
 
 from silk.auth import login_possibly_required, permissions_possibly_required
 from silk.config import SilkyConfig
-from silk.models import Profile, Request, Response, SQLQuery
-from silk.utils.data_deletion import delete_model
+from silk.utils.data_deletion import clear_silk_data
 
 
 @method_decorator(transaction.non_atomic_requests, name="dispatch")
@@ -25,10 +24,7 @@ class ClearDBView(View):
     def post(self, request, *_, **kwargs):
         context = {}
         if 'clear_all' in request.POST:
-            delete_model(Profile)
-            delete_model(SQLQuery)
-            delete_model(Response)
-            delete_model(Request)
+            clear_silk_data()
             tables = ['Response', 'SQLQuery', 'Profile', 'Request']
             context['msg'] = 'Cleared data for following silk tables: {}'.format(', '.join(tables))
 


### PR DESCRIPTION
Preserve in-flight requests (no `end_time`) when clearing or garbage-collecting silk logs so response finalization cannot hit a foreign-key IntegrityError.
Fixes #824