### PR TITLE
fix: fallback gracefully on PackageNotFoundError when determining __version__

### DIFF
--- a/project/tests/test_compat.py
+++ b/project/tests/test_compat.py
@@ -23,3 +23,12 @@ class TestByteStringCompatForResponse(TestCase):
         factory = ResponseModelFactory(mock)
         body, content = factory.body()
         self.assertDictEqual(json.loads(body), d)
+
+
+class TestPackageVersion(TestCase):
+    def test_version_defined(self):
+        import silk
+
+        self.assertIsInstance(silk.__version__, str)
+        self.assertTrue(len(silk.__version__) > 0)
+

--- a/project/tests/test_compat.py
+++ b/project/tests/test_compat.py
@@ -31,4 +31,3 @@ class TestPackageVersion(TestCase):
 
         self.assertIsInstance(silk.__version__, str)
         self.assertTrue(len(silk.__version__) > 0)
-

--- a/project/tests/test_compat.py
+++ b/project/tests/test_compat.py
@@ -26,8 +26,18 @@ class TestByteStringCompatForResponse(TestCase):
 
 
 class TestPackageVersion(TestCase):
-    def test_version_defined(self):
+    def test_version_falls_back_when_metadata_is_missing(self):
+        import importlib
+        import importlib.metadata
+        from unittest.mock import patch
+
         import silk
 
-        self.assertIsInstance(silk.__version__, str)
-        self.assertTrue(len(silk.__version__) > 0)
+        self.addCleanup(importlib.reload, silk)
+        with patch(
+            "importlib.metadata.version",
+            side_effect=importlib.metadata.PackageNotFoundError,
+        ):
+            importlib.reload(silk)
+
+        self.assertEqual(silk.__version__, "unknown")

--- a/silk/__init__.py
+++ b/silk/__init__.py
@@ -4,4 +4,3 @@ try:
     __version__ = version("django-silk")
 except PackageNotFoundError:
     __version__ = "unknown"
-

--- a/silk/__init__.py
+++ b/silk/__init__.py
@@ -1,3 +1,7 @@
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version("django-silk")
+try:
+    __version__ = version("django-silk")
+except PackageNotFoundError:
+    __version__ = "unknown"
+


### PR DESCRIPTION
### Problem

In `silk/__init__.py`, `__version__ = version("django-silk")` was executed unconditionally at import time. When `django-silk` is imported in an environment where package distribution metadata is not yet installed (e.g., from a source repository checkout, during direct module imports, or before `pip install -e .`), importing `silk` raised an unhandled `importlib.metadata.PackageNotFoundError`.

### Solution

- Catch `PackageNotFoundError` in `silk/__init__.py` and fall back to `__version__ = "unknown"`.
- Add a unit test (`TestPackageVersion`) in `project/tests/test_compat.py` to ensure `silk.__version__` is always defined.